### PR TITLE
feat(ai): add Ollama and custom OpenAI endpoint support

### DIFF
--- a/apps/api/prisma/migrations/20260119000001_add_openai_custom_endpoint/migration.sql
+++ b/apps/api/prisma/migrations/20260119000001_add_openai_custom_endpoint/migration.sql
@@ -1,0 +1,5 @@
+-- Add custom OpenAI endpoint configuration fields
+-- Enables Ollama, LiteLLM, OpenRouter, and other OpenAI-compatible providers
+
+ALTER TABLE `ai_settings` ADD COLUMN `openai_base_url` TEXT NULL;
+ALTER TABLE `ai_settings` ADD COLUMN `openai_model` VARCHAR(100) NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -444,6 +444,8 @@ model AISettings {
   openaiApiKey     String?    @map("openai_api_key") @db.Text
   openaiEnabled    Boolean    @default(false) @map("openai_enabled")
   openaiStrategy   AIStrategy @default(similar) @map("openai_strategy")
+  openaiBaseUrl    String?    @map("openai_base_url") @db.Text
+  openaiModel      String?    @map("openai_model") @db.VarChar(100)
   anthropicApiKey  String?    @map("anthropic_api_key") @db.Text
   anthropicEnabled Boolean    @default(false) @map("anthropic_enabled")
   anthropicStrategy AIStrategy @default(similar) @map("anthropic_strategy")

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -28,6 +28,8 @@ aiRouter.get('/settings', async (req, res) => {
         settings: {
           openaiEnabled: false,
           openaiConfigured: false,
+          openaiBaseUrl: null,
+          openaiModel: null,
           anthropicEnabled: false,
           anthropicConfigured: false,
         },
@@ -38,11 +40,16 @@ aiRouter.get('/settings', async (req, res) => {
     // For non-admins, hide API keys but show if configured
     const isAdmin = req.user?.role === 'admin';
     
+    // OpenAI is configured if it has an API key OR a custom base URL (for Ollama, etc.)
+    const openaiConfigured = !!settings.openaiApiKey || !!settings.openaiBaseUrl;
+    
     res.json({
       settings: {
         openaiEnabled: settings.openaiEnabled,
-        openaiConfigured: !!settings.openaiApiKey,
+        openaiConfigured,
         openaiApiKey: isAdmin ? settings.openaiApiKey : undefined,
+        openaiBaseUrl: isAdmin ? settings.openaiBaseUrl : undefined,
+        openaiModel: isAdmin ? settings.openaiModel : undefined,
         anthropicEnabled: settings.anthropicEnabled,
         anthropicConfigured: !!settings.anthropicApiKey,
         anthropicApiKey: isAdmin ? settings.anthropicApiKey : undefined,
@@ -61,6 +68,8 @@ aiRouter.put('/settings', requireAdmin, async (req, res) => {
       openaiApiKey,
       openaiEnabled,
       openaiStrategy,
+      openaiBaseUrl,
+      openaiModel,
       anthropicApiKey,
       anthropicEnabled,
       anthropicStrategy,
@@ -81,6 +90,28 @@ aiRouter.put('/settings', requireAdmin, async (req, res) => {
     if (openaiApiKey !== undefined) {
       // Allow setting to null/empty to clear, or set new key
       data.openaiApiKey = openaiApiKey || null;
+    }
+    if (openaiBaseUrl !== undefined) {
+      // Validate URL format if provided (basic check)
+      if (openaiBaseUrl && typeof openaiBaseUrl === 'string') {
+        try {
+          new URL(openaiBaseUrl);
+          data.openaiBaseUrl = openaiBaseUrl;
+        } catch {
+          res.status(400).json({ error: 'Invalid OpenAI base URL format' });
+          return;
+        }
+      } else {
+        data.openaiBaseUrl = null;
+      }
+    }
+    if (openaiModel !== undefined) {
+      // Allow setting to null/empty to clear, or set new model
+      if (openaiModel && typeof openaiModel === 'string' && openaiModel.length <= 100) {
+        data.openaiModel = openaiModel;
+      } else {
+        data.openaiModel = null;
+      }
     }
     
     if (typeof anthropicEnabled === 'boolean') {
@@ -104,6 +135,8 @@ aiRouter.put('/settings', requireAdmin, async (req, res) => {
           openaiEnabled: data.openaiEnabled ?? false,
           openaiStrategy: data.openaiStrategy ?? 'similar',
           openaiApiKey: data.openaiApiKey ?? null,
+          openaiBaseUrl: data.openaiBaseUrl ?? null,
+          openaiModel: data.openaiModel ?? null,
           anthropicEnabled: data.anthropicEnabled ?? false,
           anthropicStrategy: data.anthropicStrategy ?? 'similar',
           anthropicApiKey: data.anthropicApiKey ?? null,
@@ -114,11 +147,14 @@ aiRouter.put('/settings', requireAdmin, async (req, res) => {
     // Reload AI service settings
     await aiService.loadSettings();
 
+    // OpenAI is configured if it has an API key OR a custom base URL
+    const openaiConfigured = !!settings.openaiApiKey || !!settings.openaiBaseUrl;
+
     res.json({
       success: true,
       settings: {
         openaiEnabled: settings.openaiEnabled,
-        openaiConfigured: !!settings.openaiApiKey,
+        openaiConfigured,
         anthropicEnabled: settings.anthropicEnabled,
         anthropicConfigured: !!settings.anthropicApiKey,
       },

--- a/apps/api/src/services/ai.ts
+++ b/apps/api/src/services/ai.ts
@@ -24,10 +24,14 @@ interface AISettings {
   openaiApiKey: string | null;
   openaiEnabled: boolean;
   openaiStrategy: AIStrategy;
+  openaiBaseUrl: string | null;
+  openaiModel: string | null;
   anthropicApiKey: string | null;
   anthropicEnabled: boolean;
   anthropicStrategy: AIStrategy;
 }
+
+const DEFAULT_OPENAI_MODEL = 'gpt-3.5-turbo';
 
 const STRATEGY_PROMPTS: Record<AIStrategy, string> = {
   similar: 'find 5 similar artists with comparable sound, style, and genre',
@@ -53,14 +57,23 @@ export class AIService {
       openaiApiKey: settings.openaiApiKey,
       openaiEnabled: settings.openaiEnabled,
       openaiStrategy: settings.openaiStrategy,
+      openaiBaseUrl: settings.openaiBaseUrl,
+      openaiModel: settings.openaiModel,
       anthropicApiKey: settings.anthropicApiKey,
       anthropicEnabled: settings.anthropicEnabled,
       anthropicStrategy: settings.anthropicStrategy,
     };
 
     // Initialize clients if enabled
-    if (this.settings.openaiEnabled && this.settings.openaiApiKey) {
-      this.openaiClient = new OpenAI({ apiKey: this.settings.openaiApiKey });
+    // For custom base URLs (Ollama, LiteLLM, etc.), API key may not be required
+    const hasOpenAIKey = !!this.settings.openaiApiKey;
+    const hasCustomBaseUrl = !!this.settings.openaiBaseUrl;
+    
+    if (this.settings.openaiEnabled && (hasOpenAIKey || hasCustomBaseUrl)) {
+      this.openaiClient = new OpenAI({
+        apiKey: this.settings.openaiApiKey || 'not-required',
+        ...(this.settings.openaiBaseUrl && { baseURL: this.settings.openaiBaseUrl }),
+      });
     }
     
     if (this.settings.anthropicEnabled && this.settings.anthropicApiKey) {
@@ -148,8 +161,9 @@ Return ONLY a JSON array of artist names, nothing else. Format:
 Return at least 5 unique artists total, maximum 10.`;
 
     try {
+      const model = this.settings?.openaiModel || DEFAULT_OPENAI_MODEL;
       const response = await this.openaiClient.chat.completions.create({
-        model: 'gpt-3.5-turbo',
+        model,
         messages: [
           {
             role: 'system',
@@ -283,8 +297,9 @@ Return ONLY a JSON array of artist names, nothing else. Format:
     // Try OpenAI if enabled
     if (this.settings.openaiEnabled && this.openaiClient) {
       try {
+        const model = this.settings.openaiModel || DEFAULT_OPENAI_MODEL;
         const response = await this.openaiClient.chat.completions.create({
-          model: 'gpt-3.5-turbo',
+          model,
           messages: [
             {
               role: 'system',
@@ -359,8 +374,12 @@ Return ONLY a JSON array of artist names, nothing else. Format:
     
     if (!this.settings) return false;
     
+    // OpenAI is available if enabled AND (has API key OR has custom base URL)
+    const openaiAvailable = this.settings.openaiEnabled && 
+      (!!this.settings.openaiApiKey || !!this.settings.openaiBaseUrl);
+    
     return (
-      (this.settings.openaiEnabled && !!this.settings.openaiApiKey) ||
+      openaiAvailable ||
       (this.settings.anthropicEnabled && !!this.settings.anthropicApiKey)
     );
   }

--- a/apps/api/tests/api/ai-routes.test.ts
+++ b/apps/api/tests/api/ai-routes.test.ts
@@ -1,0 +1,430 @@
+/**
+ * AI Routes API Tests
+ * 
+ * Tests for AI settings endpoints including Ollama support
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { aiRouter } from '../../src/routes/ai.js';
+
+// Mock dependencies
+vi.mock('../../src/lib/db.js', () => ({
+  default: {
+    aISettings: {
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../../src/services/ai.js', () => ({
+  aiService: {
+    loadSettings: vi.fn(),
+    getRecommendations: vi.fn(),
+    isAvailable: vi.fn(),
+  },
+}));
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  requireAuth: vi.fn((req: any, _res: any, next: any) => {
+    req.user = { id: 1, username: 'test', role: 'user' };
+    next();
+  }),
+  requireAdmin: vi.fn((req: any, _res: any, next: any) => {
+    req.user = { id: 1, username: 'test', role: 'admin' };
+    next();
+  }),
+}));
+
+import prisma from '../../src/lib/db.js';
+import { aiService } from '../../src/services/ai.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/ai', aiRouter);
+
+describe('AI Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/ai/settings', () => {
+    it('should return default settings when none exist', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue(null);
+
+      const res = await request(app).get('/api/ai/settings');
+
+      expect(res.status).toBe(200);
+      expect(res.body.settings).toEqual({
+        openaiEnabled: false,
+        openaiConfigured: false,
+        openaiBaseUrl: null,
+        openaiModel: null,
+        anthropicEnabled: false,
+        anthropicConfigured: false,
+      });
+    });
+
+    it('should return settings for admin user', async () => {
+      // Override requireAuth to return admin user
+      const { requireAuth } = await import('../../src/middleware/auth.js');
+      vi.mocked(requireAuth).mockImplementation((req: any, _res: any, next: any) => {
+        req.user = { id: 1, username: 'admin', role: 'admin' };
+        next();
+      });
+
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: 'sk-test-key',
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app).get('/api/ai/settings');
+
+      expect(res.status).toBe(200);
+      expect(res.body.settings.openaiApiKey).toBe('sk-test-key');
+      expect(res.body.settings.openaiBaseUrl).toBe('http://localhost:11434/v1');
+      expect(res.body.settings.openaiModel).toBe('llama3.2');
+      expect(res.body.settings.openaiConfigured).toBe(true);
+    });
+
+    it('should hide API keys for non-admin users', async () => {
+      // Override requireAuth to return non-admin user
+      const { requireAuth } = await import('../../src/middleware/auth.js');
+      vi.mocked(requireAuth).mockImplementation((req: any, _res: any, next: any) => {
+        req.user = { id: 2, username: 'user', role: 'user' };
+        next();
+      });
+
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: 'sk-test-key',
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app).get('/api/ai/settings');
+
+      expect(res.status).toBe(200);
+      expect(res.body.settings.openaiApiKey).toBeUndefined();
+      expect(res.body.settings.openaiBaseUrl).toBeUndefined();
+      expect(res.body.settings.openaiModel).toBeUndefined();
+      expect(res.body.settings.openaiConfigured).toBe(true);
+    });
+
+    it('should mark OpenAI as configured when base URL is set (Ollama mode)', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app).get('/api/ai/settings');
+
+      expect(res.status).toBe(200);
+      expect(res.body.settings.openaiConfigured).toBe(true);
+    });
+  });
+
+  describe('PUT /api/ai/settings', () => {
+    it('should create new settings with Ollama configuration', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.aISettings.create).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiEnabled: true,
+          openaiBaseUrl: 'http://localhost:11434/v1',
+          openaiModel: 'llama3.2',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.settings.openaiConfigured).toBe(true);
+      expect(prisma.aISettings.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          openaiEnabled: true,
+          openaiBaseUrl: 'http://localhost:11434/v1',
+          openaiModel: 'llama3.2',
+        }),
+      });
+      expect(aiService.loadSettings).toHaveBeenCalled();
+    });
+
+    it('should update existing settings with Ollama configuration', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: 'sk-old-key',
+        openaiEnabled: false,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      vi.mocked(prisma.aISettings.update).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiEnabled: true,
+          openaiBaseUrl: 'http://localhost:11434/v1',
+          openaiModel: 'llama3.2',
+          openaiApiKey: null, // Clear API key when using Ollama
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.settings.openaiConfigured).toBe(true);
+      expect(prisma.aISettings.update).toHaveBeenCalled();
+      expect(aiService.loadSettings).toHaveBeenCalled();
+    });
+
+    it('should reject invalid URL format', async () => {
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiBaseUrl: 'not-a-valid-url',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid OpenAI base URL format');
+    });
+
+    it('should accept valid URLs including localhost', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.aISettings.create).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiBaseUrl: 'http://localhost:11434/v1',
+        });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('should accept valid URLs including IP addresses', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.aISettings.create).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://192.168.1.100:11434/v1',
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiBaseUrl: 'http://192.168.1.100:11434/v1',
+        });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('should validate model name length', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue(null);
+      vi.mocked(prisma.aISettings.create).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: 'a'.repeat(100),
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiModel: 'a'.repeat(100), // Max length
+        });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('should reject model names longer than 100 characters', async () => {
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiModel: 'a'.repeat(101), // Too long
+        });
+
+      // Should accept but truncate to null (based on implementation)
+      expect(res.status).toBe(200);
+      expect(prisma.aISettings.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          openaiModel: null,
+        }),
+      });
+    });
+
+    it('should allow clearing base URL and model', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      vi.mocked(prisma.aISettings.update).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const res = await request(app)
+        .put('/api/ai/settings')
+        .send({
+          openaiBaseUrl: '',
+          openaiModel: '',
+        });
+
+      expect(res.status).toBe(200);
+      expect(prisma.aISettings.update).toHaveBeenCalledWith({
+        where: { id: 1 },
+        data: expect.objectContaining({
+          openaiBaseUrl: null,
+          openaiModel: null,
+        }),
+      });
+    });
+  });
+
+  describe('POST /api/ai/test', () => {
+    it('should test OpenAI connection', async () => {
+      vi.mocked(aiService.isAvailable).mockResolvedValue(true);
+      vi.mocked(aiService.getRecommendations).mockResolvedValue([
+        { name: 'Test Artist', source: 'openai', strategy: 'similar' },
+      ]);
+
+      const res = await request(app)
+        .post('/api/ai/test')
+        .send({ provider: 'openai' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toContain('openai');
+    });
+
+    it('should reject invalid provider', async () => {
+      const res = await request(app)
+        .post('/api/ai/test')
+        .send({ provider: 'invalid' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('openai or anthropic');
+    });
+  });
+
+  describe('GET /api/ai/status', () => {
+    it('should return available status when Ollama is configured', async () => {
+      vi.mocked(aiService.isAvailable).mockResolvedValue(true);
+
+      const res = await request(app).get('/api/ai/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.available).toBe(true);
+    });
+
+    it('should return unavailable status when no AI is configured', async () => {
+      vi.mocked(aiService.isAvailable).mockResolvedValue(false);
+
+      const res = await request(app).get('/api/ai/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.available).toBe(false);
+    });
+  });
+});

--- a/apps/api/tests/services/ai.test.ts
+++ b/apps/api/tests/services/ai.test.ts
@@ -80,6 +80,8 @@ describe('AIService', () => {
         openaiApiKey: 'test-key',
         openaiEnabled: true,
         openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
         anthropicApiKey: null,
         anthropicEnabled: false,
         anthropicStrategy: 'similar',
@@ -111,6 +113,8 @@ describe('AIService', () => {
         openaiApiKey: 'test-openai-key',
         openaiEnabled: true,
         openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
         anthropicApiKey: null,
         anthropicEnabled: false,
         anthropicStrategy: 'similar',
@@ -140,6 +144,8 @@ describe('AIService', () => {
         openaiApiKey: 'test-openai-key',
         openaiEnabled: true,
         openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
         anthropicApiKey: null,
         anthropicEnabled: false,
         anthropicStrategy: 'similar',
@@ -160,6 +166,133 @@ describe('AIService', () => {
 
       expect(result.artists).toEqual(['Bonobo', 'Four Tet', 'Caribou']);
       expect(result.providers).toEqual(['openai']);
+    });
+
+    it('should use custom model when configured', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: 'test-key',
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: 'gpt-4o',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockOpenAICreate.mockResolvedValue({
+        choices: [{ message: { content: '["Test Artist"]' } }],
+      });
+
+      const service = new AIService();
+      await service.searchByPrompt('jazz fusion');
+
+      expect(mockOpenAICreate).toHaveBeenCalled();
+      const callArgs = mockOpenAICreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('gpt-4o');
+    });
+
+    it('should use default model when not configured', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: 'test-key',
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockOpenAICreate.mockResolvedValue({
+        choices: [{ message: { content: '["Test Artist"]' } }],
+      });
+
+      const service = new AIService();
+      await service.searchByPrompt('jazz fusion');
+
+      expect(mockOpenAICreate).toHaveBeenCalled();
+      const callArgs = mockOpenAICreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('gpt-3.5-turbo');
+    });
+
+    it('should work with custom base URL and no API key (Ollama mode)', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: 'llama3.2',
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      mockOpenAICreate.mockResolvedValue({
+        choices: [{ message: { content: '["Local Artist"]' } }],
+      });
+
+      const service = new AIService();
+      const result = await service.searchByPrompt('electronic music');
+
+      expect(result.artists).toEqual(['Local Artist']);
+      expect(result.providers).toEqual(['openai']);
+      expect(mockOpenAICreate).toHaveBeenCalled();
+      const callArgs = mockOpenAICreate.mock.calls[0][0];
+      expect(callArgs.model).toBe('llama3.2');
+    });
+  });
+
+  describe('isAvailable', () => {
+    it('should return true when OpenAI has custom base URL but no API key', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: 'http://localhost:11434/v1',
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const service = new AIService();
+      const available = await service.isAvailable();
+
+      expect(available).toBe(true);
+    });
+
+    it('should return false when OpenAI is enabled but has neither API key nor base URL', async () => {
+      vi.mocked(prisma.aISettings.findFirst).mockResolvedValue({
+        id: 1,
+        openaiApiKey: null,
+        openaiEnabled: true,
+        openaiStrategy: 'similar',
+        openaiBaseUrl: null,
+        openaiModel: null,
+        anthropicApiKey: null,
+        anthropicEnabled: false,
+        anthropicStrategy: 'similar',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const service = new AIService();
+      const available = await service.isAvailable();
+
+      expect(available).toBe(false);
     });
   });
 });

--- a/apps/web/src/components/settings/ai-settings.tsx
+++ b/apps/web/src/components/settings/ai-settings.tsx
@@ -9,6 +9,8 @@ interface AISettingsData {
   openaiEnabled: boolean;
   openaiConfigured: boolean;
   openaiApiKey?: string;
+  openaiBaseUrl?: string;
+  openaiModel?: string;
   anthropicEnabled: boolean;
   anthropicConfigured: boolean;
   anthropicApiKey?: string;
@@ -22,6 +24,8 @@ export function AISettings() {
     anthropicConfigured: false,
   });
   const [openaiKey, setOpenaiKey] = useState('');
+  const [openaiBaseUrl, setOpenaiBaseUrl] = useState('');
+  const [openaiModel, setOpenaiModel] = useState('');
   const [anthropicKey, setAnthropicKey] = useState('');
   const [showOpenaiKey, setShowOpenaiKey] = useState(false);
   const [showAnthropicKey, setShowAnthropicKey] = useState(false);
@@ -37,6 +41,12 @@ export function AISettings() {
         setSettings(data.settings);
         if (data.settings.openaiApiKey) {
           setOpenaiKey(data.settings.openaiApiKey);
+        }
+        if (data.settings.openaiBaseUrl) {
+          setOpenaiBaseUrl(data.settings.openaiBaseUrl);
+        }
+        if (data.settings.openaiModel) {
+          setOpenaiModel(data.settings.openaiModel);
         }
         if (data.settings.anthropicApiKey) {
           setAnthropicKey(data.settings.anthropicApiKey);
@@ -59,6 +69,8 @@ export function AISettings() {
       const { error } = await api.put('/api/ai/settings', {
         openaiEnabled: settings.openaiEnabled,
         openaiApiKey: openaiKey || undefined,
+        openaiBaseUrl: openaiBaseUrl || undefined,
+        openaiModel: openaiModel || undefined,
         anthropicEnabled: settings.anthropicEnabled,
         anthropicApiKey: anthropicKey || undefined,
       });
@@ -122,9 +134,9 @@ export function AISettings() {
         <div className="rounded-lg border p-4 space-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="font-semibold">OpenAI (GPT-4)</h3>
+              <h3 className="font-semibold">OpenAI-Compatible</h3>
               <p className="text-sm text-muted-foreground">
-                Use OpenAI&apos;s GPT models for recommendations
+                Use OpenAI, Ollama, LiteLLM, OpenRouter, or other compatible providers
               </p>
             </div>
             <button
@@ -161,10 +173,40 @@ export function AISettings() {
                     {showOpenaiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>
                 </div>
-                {settings.openaiConfigured && (
-                  <p className="text-xs text-green-600">✓ API key configured</p>
-                )}
+                <p className="text-xs text-muted-foreground">
+                  Required for OpenAI. Optional when using a custom base URL (e.g., Ollama).
+                </p>
               </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Base URL (Optional)</label>
+                <Input
+                  type="text"
+                  value={openaiBaseUrl}
+                  onChange={(e) => setOpenaiBaseUrl(e.target.value)}
+                  placeholder="https://api.openai.com/v1 (default)"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Leave empty for OpenAI. For Ollama use http://localhost:11434/v1
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Model (Optional)</label>
+                <Input
+                  type="text"
+                  value={openaiModel}
+                  onChange={(e) => setOpenaiModel(e.target.value)}
+                  placeholder="gpt-3.5-turbo (default)"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Model name varies by provider (e.g., llama3.2, mistral, gpt-4o)
+                </p>
+              </div>
+
+              {settings.openaiConfigured && (
+                <p className="text-xs text-green-600">✓ OpenAI-compatible provider configured</p>
+              )}
             </>
           )}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,29 +134,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
-    "apps/api/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "apps/web": {
       "name": "@mixarr/web",
       "version": "1.0.0",
@@ -262,7 +239,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4364,7 +4340,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7878,6 +7853,34 @@
         "turbo-windows-arm64": "2.6.3"
       }
     },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.6.3.tgz",
+      "integrity": "sha512-BlJJDc1CQ7SK5Y5qnl7AzpkvKSnpkfPmnA+HeU/sgny3oHZckPV2776ebO2M33CYDSor7+8HQwaodY++IINhYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.6.3.tgz",
+      "integrity": "sha512-MwVt7rBKiOK7zdYerenfCRTypefw4kZCue35IJga9CH1+S50+KTiCkT6LBqo0hHeoH2iKuI0ldTF2a0aB72z3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/turbo-linux-64": {
       "version": "2.6.3",
       "cpu": [
@@ -7888,6 +7891,48 @@
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.6.3.tgz",
+      "integrity": "sha512-MterpZQmjXyr4uM7zOgFSFL3oRdNKeflY7nsjxJb2TklsYqiu3Z9pQ4zRVFFH8n0mLGna7MbQMZuKoWqqHb45w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.6.3.tgz",
+      "integrity": "sha512-biDU70v9dLwnBdLf+daoDlNJVvqOOP8YEjqNipBHzgclbQlXbsi6Gqqelp5er81Qo3BiRgmTNx79oaZQTPb07Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.6.3.tgz",
+      "integrity": "sha512-dDHVKpSeukah3VsI/xMEKeTnV9V9cjlpFSUs4bmsUiLu3Yv2ENlgVEZv65wxbeE0bh0jjpmElDT+P1KaCxArQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/type-check": {


### PR DESCRIPTION
Add support for OpenAI-compatible providers including Ollama, LiteLLM, and OpenRouter by allowing custom base URL configuration.

Changes:
- Add openaiBaseUrl and openaiModel fields to AISettings schema
- Update AI service to initialize OpenAI client with custom base URL
- Allow API key to be optional when using custom base URL (Ollama mode)
- Add comprehensive test coverage for AI routes and Ollama scenarios
- Update frontend UI with Ollama-specific configuration fields and help text
- Add database migration for new AI settings fields

This enables users to use local LLMs via Ollama or other OpenAI-compatible providers without requiring an OpenAI API key.

<img width="1341" height="434" alt="image" src="https://github.com/user-attachments/assets/48f74e32-053c-42ca-88ce-1a3c73c65bbd" />

Closes #11