### PR TITLE
UX/UI Polish: Shared Components, Semantic Colors, Skeleton Loading, Mobile Nav

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,7 +26,7 @@
     "@prisma/client": "^5.22.0",
     "bcryptjs": "^2.4.3",
     "bullmq": "^5.25.2",
-    "connect-redis": "^9.0.0",
+    "connect-redis": "7.1.1",
     "cors": "^2.8.5",
     "cron": "^3.1.7",
     "dotenv": "^16.4.5",

--- a/apps/api/src/auth/passport.ts
+++ b/apps/api/src/auth/passport.ts
@@ -3,7 +3,7 @@ import passport from 'passport';
 import { Strategy as LocalStrategy } from 'passport-local';
 import bcrypt from 'bcryptjs';
 import session from 'express-session';
-import { RedisStore } from 'connect-redis';
+import RedisStore from 'connect-redis';
 import Redis from 'ioredis';
 import prisma from '../lib/db.js';
 import { createLogger } from '../lib/logger.js';

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -32,6 +32,12 @@ export const errorHandler: ErrorRequestHandler = (
     stack: err.stack,
   });
 
+  // Guard against sending a response when headers have already been sent
+  // (e.g., session save errors after the response was flushed)
+  if (res.headersSent) {
+    return;
+  }
+
   // Handle Zod validation errors
   if (err instanceof ZodError) {
     const response: ErrorResponse = {

--- a/apps/web/src/app/connections/components/ConnectionCard.tsx
+++ b/apps/web/src/app/connections/components/ConnectionCard.tsx
@@ -51,7 +51,7 @@ export function ConnectionCard({
   onPreview,
 }: ConnectionCardProps) {
   return (
-    <Card>
+    <Card interactive>
       <CardHeader className="pb-3">
         <div className="flex items-center gap-3">
           <div

--- a/apps/web/src/app/connections/page.tsx
+++ b/apps/web/src/app/connections/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
 import { PageHeader } from '@/components/layout/page-header';
 import { useAuth } from '@/lib/auth';
@@ -32,6 +33,9 @@ export default function ConnectionsPage() {
   const [showModal, setShowModal] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [preselectedType, setPreselectedType] = useState<string | undefined>(undefined);
+
+  // Confirm dialog state
+  const [confirmTarget, setConfirmTarget] = useState<number | null>(null);
 
   // Welcome banner
   const [welcomeDismissed, setWelcomeDismissed] = useState(false);
@@ -113,9 +117,10 @@ export default function ConnectionsPage() {
     setPreselectedType(undefined);
   };
 
-  const handleDelete = (id: number) => {
-    if (!confirm('Delete this connection?')) return;
-    deleteConnection(id);
+  const handleDeleteClick = (id: number) => setConfirmTarget(id);
+  const confirmDelete = () => {
+    if (confirmTarget !== null) deleteConnection(confirmTarget);
+    setConfirmTarget(null);
   };
 
   // Derived state
@@ -179,12 +184,22 @@ export default function ConnectionsPage() {
               if (conn) openModal(conn);
             }}
             onTest={(id) => testConnection(id)}
-            onDelete={(id) => handleDelete(id)}
+            onDelete={(id) => handleDeleteClick(id)}
             testingId={testingId}
             onPreview={(id, t) => handlePreview(id, t)}
           />
         ))}
       </div>
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onClose={() => setConfirmTarget(null)}
+        onConfirm={confirmDelete}
+        title="Delete connection?"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+      />
 
       {/* Connection Wizard */}
       <ConnectionWizard

--- a/apps/web/src/app/discover/page.tsx
+++ b/apps/web/src/app/discover/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
 import { Loading } from '@/components/ui/loading';
@@ -630,33 +631,21 @@ export default function DiscoverPage() {
                 <div className="grid grid-cols-1 gap-3 p-3 bg-muted/50 rounded-lg">
                   <div className="text-sm font-medium">Add Settings</div>
                   <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-                    <select
-                      className="px-3 py-2 rounded-md border bg-background text-sm"
-                      value={selectedQuality || ''}
+                    <Select
+                      value={String(selectedQuality || '')}
                       onChange={(e) => setSelectedQuality(Number(e.target.value))}
-                    >
-                      {profiles.qualityProfiles.map(p => (
-                        <option key={p.id} value={p.id}>{p.name}</option>
-                      ))}
-                    </select>
-                    <select
-                      className="px-3 py-2 rounded-md border bg-background text-sm"
-                      value={selectedMetadata || ''}
+                      options={profiles.qualityProfiles.map(p => ({ value: String(p.id), label: p.name }))}
+                    />
+                    <Select
+                      value={String(selectedMetadata || '')}
                       onChange={(e) => setSelectedMetadata(Number(e.target.value))}
-                    >
-                      {profiles.metadataProfiles.map(p => (
-                        <option key={p.id} value={p.id}>{p.name}</option>
-                      ))}
-                    </select>
-                    <select
-                      className="px-3 py-2 rounded-md border bg-background text-sm"
-                      value={selectedRootFolder || ''}
+                      options={profiles.metadataProfiles.map(p => ({ value: String(p.id), label: p.name }))}
+                    />
+                    <Select
+                      value={String(selectedRootFolder || '')}
                       onChange={(e) => setSelectedRootFolder(e.target.value)}
-                    >
-                      {profiles.rootFolders.map(p => (
-                        <option key={p.id} value={p.path}>{p.path}</option>
-                      ))}
-                    </select>
+                      options={profiles.rootFolders.map(p => ({ value: p.path, label: p.path }))}
+                    />
                   </div>
                 </div>
               )}
@@ -805,42 +794,30 @@ export default function DiscoverPage() {
         <div className="space-y-4 py-4">
           <div className="space-y-2">
             <label className="text-sm font-medium">Quality Profile</label>
-            <select
-              className="w-full border rounded-lg px-3 py-2 bg-background"
-              value={addProfiles.qualityProfileId}
+            <Select
+              value={String(addProfiles.qualityProfileId)}
               onChange={(e) => setAddProfiles(p => ({ ...p, qualityProfileId: Number(e.target.value) }))}
               disabled={isBulkAdding}
-            >
-              {profiles?.qualityProfiles.map(p => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </select>
+              options={profiles?.qualityProfiles.map(p => ({ value: String(p.id), label: p.name })) ?? []}
+            />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium">Metadata Profile</label>
-            <select
-              className="w-full border rounded-lg px-3 py-2 bg-background"
-              value={addProfiles.metadataProfileId}
+            <Select
+              value={String(addProfiles.metadataProfileId)}
               onChange={(e) => setAddProfiles(p => ({ ...p, metadataProfileId: Number(e.target.value) }))}
               disabled={isBulkAdding}
-            >
-              {profiles?.metadataProfiles.map(p => (
-                <option key={p.id} value={p.id}>{p.name}</option>
-              ))}
-            </select>
+              options={profiles?.metadataProfiles.map(p => ({ value: String(p.id), label: p.name })) ?? []}
+            />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium">Root Folder</label>
-            <select
-              className="w-full border rounded-lg px-3 py-2 bg-background"
+            <Select
               value={addProfiles.rootFolderPath}
               onChange={(e) => setAddProfiles(p => ({ ...p, rootFolderPath: e.target.value }))}
               disabled={isBulkAdding}
-            >
-              {profiles?.rootFolders.map(f => (
-                <option key={f.path} value={f.path}>{f.path}</option>
-              ))}
-            </select>
+              options={profiles?.rootFolders.map(f => ({ value: f.path, label: f.path })) ?? []}
+            />
           </div>
           
           {isBulkAdding && (

--- a/apps/web/src/app/downloads/page.tsx
+++ b/apps/web/src/app/downloads/page.tsx
@@ -4,9 +4,8 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { EmptyState } from '@/components/ui';
+import { EmptyState, Skeleton } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
-import { Loading } from '@/components/ui/loading';
 import { PageHeader } from '@/components/layout/page-header';
 import { useSlskdDownloads, useRetrySlskdDownload, useCancelSlskdDownload, SlskdDownload } from '@/lib/hooks';
 import CheckCircle from 'lucide-react/dist/esm/icons/check-circle';
@@ -300,7 +299,18 @@ export default function DownloadsPage() {
 
       {/* Downloads List */}
       {isLoading ? (
-        <Loading />
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 p-4 rounded-lg border bg-card">
+              <Skeleton className="w-12 h-12 rounded-md" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-1/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+              <Skeleton className="h-6 w-16 rounded-full" />
+            </div>
+          ))}
+        </div>
       ) : downloads.length === 0 ? (
         <EmptyState
           icon={Download}

--- a/apps/web/src/app/downloads/page.tsx
+++ b/apps/web/src/app/downloads/page.tsx
@@ -50,7 +50,7 @@ function getStatusBadge(status: SlskdDownload['status']) {
     case 'pending':
       return <Badge variant="secondary"><Clock className="h-3 w-3 mr-1" />Pending</Badge>;
     case 'downloading':
-      return <Badge variant="default" className="bg-blue-600"><Loader2 className="h-3 w-3 mr-1 animate-spin" />Downloading</Badge>;
+      return <Badge variant="default" className="bg-status-info"><Loader2 className="h-3 w-3 mr-1 animate-spin" />Downloading</Badge>;
     case 'completed':
       return <Badge variant="success"><CheckCircle className="h-3 w-3 mr-1" />Completed</Badge>;
     case 'failed':

--- a/apps/web/src/app/downloads/page.tsx
+++ b/apps/web/src/app/downloads/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
 import { Loading } from '@/components/ui/loading';
 import { PageHeader } from '@/components/layout/page-header';
@@ -301,17 +302,13 @@ export default function DownloadsPage() {
       {isLoading ? (
         <Loading />
       ) : downloads.length === 0 ? (
-        <Card>
-          <CardContent className="p-8 text-center">
-            <Download className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-            <h3 className="text-lg font-semibold mb-2">No downloads</h3>
-            <p className="text-muted-foreground">
-              {statusFilter === 'all' 
-                ? 'Downloads from slskd will appear here.'
-                : `No ${statusFilter} downloads.`}
-            </p>
-          </CardContent>
-        </Card>
+        <EmptyState
+          icon={Download}
+          title="No downloads"
+          description={statusFilter === 'all'
+            ? 'Downloads from slskd will appear here.'
+            : `No ${statusFilter} downloads.`}
+        />
       ) : (
         <div className="space-y-4">
           {downloads.map((download) => (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -192,6 +192,20 @@
   .font-display {
     @apply font-semibold tracking-tight;
   }
+
+  /* Status color text utilities */
+  .text-status-success {
+    color: hsl(var(--success));
+  }
+  .text-status-warning {
+    color: hsl(var(--warning));
+  }
+  .text-status-error {
+    color: hsl(var(--error));
+  }
+  .text-status-info {
+    color: hsl(var(--info, 210 60% 50%));
+  }
 }
 
 /* Reduced motion accessibility */

--- a/apps/web/src/app/jobs/page.tsx
+++ b/apps/web/src/app/jobs/page.tsx
@@ -54,11 +54,11 @@ function getJobStatus(job: Job): 'completed' | 'failed' | 'active' | 'waiting' {
 function JobStatusBadge({ status }: { status: ReturnType<typeof getJobStatus> }) {
   switch (status) {
     case 'completed':
-      return <Badge variant="default" className="bg-green-600"><CheckCircle className="h-3 w-3 mr-1" />Completed</Badge>;
+      return <Badge variant="default" className="bg-status-success"><CheckCircle className="h-3 w-3 mr-1" />Completed</Badge>;
     case 'failed':
       return <Badge variant="destructive"><XCircle className="h-3 w-3 mr-1" />Failed</Badge>;
     case 'active':
-      return <Badge variant="default" className="bg-blue-600"><Loader2 className="h-3 w-3 mr-1 animate-spin" />Running</Badge>;
+      return <Badge variant="default" className="bg-status-info"><Loader2 className="h-3 w-3 mr-1 animate-spin" />Running</Badge>;
     case 'waiting':
       return <Badge variant="secondary"><Clock className="h-3 w-3 mr-1" />Waiting</Badge>;
   }
@@ -218,7 +218,7 @@ export default function JobsPage() {
                       {status === 'completed' && job.returnvalue && (
                         <div className="text-sm mt-1">
                           {job.returnvalue.artistsFound !== undefined && (
-                            <span className="text-green-600">
+                            <span className="text-status-success">
                               Found: {job.returnvalue.artistsFound}, Added: {job.returnvalue.artistsAdded || 0}
                             </span>
                           )}

--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
@@ -85,6 +86,7 @@ export default function LibraryPage() {
   const [isStartingFix, setIsStartingFix] = useState(false);
   const [isCancellingFix, setIsCancellingFix] = useState(false);
   const [fixingArtistId, setFixingArtistId] = useState<number | null>(null);
+  const [confirmFixAll, setConfirmFixAll] = useState(false);
 
   const handleDuplicateCountChange = useCallback((count: number) => {
     setDuplicateCount(count);
@@ -132,17 +134,14 @@ export default function LibraryPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fixJob?.status, fixJob?.jobId]);
 
-  const handleFixAll = async () => {
+  const handleFixAllClick = () => {
     const artistsWithIssues = artists.filter(a => a.needsRefresh).length;
     if (artistsWithIssues === 0) return;
+    setConfirmFixAll(true);
+  };
 
-    const confirmed = window.confirm(
-      `This will attempt to fix metadata for ${artistsWithIssues} artists with issues.\n\n` +
-      `This may take several minutes and will make requests to Lidarr.\n\n` +
-      `Continue?`
-    );
-    if (!confirmed) return;
-
+  const confirmFixAllAction = async () => {
+    setConfirmFixAll(false);
     setIsStartingFix(true);
     const { data, error } = await api.post<{ jobId: string | null; total: number; message?: string }>('/api/search/lidarr/artists/fix-all');
     
@@ -358,7 +357,7 @@ export default function LibraryPage() {
           ) : (
             <Button 
               variant="outline" 
-              onClick={handleFixAll} 
+              onClick={handleFixAllClick} 
               disabled={artistsNeedingFix === 0 || isStartingFix || isLoading}
             >
               <Wrench className={`h-4 w-4 mr-2 ${isStartingFix ? 'animate-spin' : ''}`} />
@@ -468,6 +467,16 @@ export default function LibraryPage() {
           Duplicates{duplicateCount > 0 ? ` (${duplicateCount})` : ''}
         </button>
       </div>
+
+      <ConfirmDialog
+        open={confirmFixAll}
+        onClose={() => setConfirmFixAll(false)}
+        onConfirm={confirmFixAllAction}
+        title="Fix metadata?"
+        description={`This will attempt to fix metadata for ${artistsNeedingFix} artists with issues. This may take several minutes and will make requests to Lidarr.`}
+        confirmLabel="Fix Metadata"
+        variant="warning"
+      />
 
       {/* Tab Content */}
       {activeTab === 'duplicates' ? (

--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ConfirmDialog } from '@/components/ui';
+import { ConfirmDialog, Tabs, Tab } from '@/components/ui';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
@@ -443,30 +443,10 @@ export default function LibraryPage() {
       )}
 
       {/* Tabs */}
-      <div className="flex gap-2 mb-6 border-b">
-        <button
-          onClick={() => setActiveTab('health')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'health'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          <AlertTriangle className="w-4 h-4 inline mr-2" />
-          Health Issues
-        </button>
-        <button
-          onClick={() => setActiveTab('duplicates')}
-          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-            activeTab === 'duplicates'
-              ? 'border-primary text-primary'
-              : 'border-transparent text-muted-foreground hover:text-foreground'
-          }`}
-        >
-          <Copy className="w-4 h-4 inline mr-2" />
-          Duplicates{duplicateCount > 0 ? ` (${duplicateCount})` : ''}
-        </button>
-      </div>
+      <Tabs value={activeTab} onChange={(v) => setActiveTab(v as TabType)} className="mb-6">
+        <Tab value="health" label="Health Issues" icon={<AlertTriangle className="w-4 h-4" />} />
+        <Tab value="duplicates" label="Duplicates" badge={duplicateCount > 0 ? duplicateCount : undefined} icon={<Copy className="w-4 h-4" />} />
+      </Tabs>
 
       <ConfirmDialog
         open={confirmFixAll}

--- a/apps/web/src/app/library/page.tsx
+++ b/apps/web/src/app/library/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ConfirmDialog, Tabs, Tab } from '@/components/ui';
+import { ConfirmDialog, Tabs, Tab, Skeleton } from '@/components/ui';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
@@ -549,8 +549,19 @@ export default function LibraryPage() {
         </CardHeader>
         <CardContent>
           {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
+            <div className="space-y-2">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-4 py-3 px-4">
+                  <Skeleton className="w-10 h-10 rounded-md" />
+                  <Skeleton className="h-4 w-1/4" />
+                  <Skeleton className="h-4 w-12" />
+                  <div className="flex gap-2 ml-auto">
+                    <Skeleton className="w-5 h-5 rounded" />
+                    <Skeleton className="w-5 h-5 rounded" />
+                    <Skeleton className="w-5 h-5 rounded" />
+                  </div>
+                </div>
+              ))}
             </div>
           ) : filteredArtists.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -12,6 +12,9 @@ import EyeOff from 'lucide-react/dist/esm/icons/eye-off';
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import LogIn from 'lucide-react/dist/esm/icons/log-in';
 import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import MonitorPlay from 'lucide-react/dist/esm/icons/monitor-play';
+import KeyRound from 'lucide-react/dist/esm/icons/key-round';
+import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
 
 function LoginPageContent() {
   const [username, setUsername] = useState('');
@@ -185,13 +188,13 @@ function LoginPageContent() {
                       </svg>
                     )}
                     {provider.type === 'plex' && (
-                      <span className="mr-2 text-lg">🟠</span>
+                      <MonitorPlay className="w-5 h-5 mr-2 text-orange-500" />
                     )}
                     {provider.type === 'ldap' && (
-                      <span className="mr-2 text-lg">🔑</span>
+                      <KeyRound className="w-5 h-5 mr-2" />
                     )}
                     {provider.type === 'saml' && (
-                      <span className="mr-2 text-lg">🔐</span>
+                      <ShieldCheck className="w-5 h-5 mr-2" />
                     )}
                     Login with {provider.name}
                   </Button>

--- a/apps/web/src/app/logs/page.tsx
+++ b/apps/web/src/app/logs/page.tsx
@@ -20,10 +20,10 @@ import Loader2 from 'lucide-react/dist/esm/icons/loader-2';
 import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw';
 
 const levelConfig = {
-  debug: { icon: Bug, color: 'text-gray-500', bg: 'bg-gray-500/10' },
-  info: { icon: Info, color: 'text-blue-500', bg: 'bg-blue-500/10' },
-  warn: { icon: AlertTriangle, color: 'text-yellow-500', bg: 'bg-yellow-500/10' },
-  error: { icon: AlertCircle, color: 'text-red-500', bg: 'bg-red-500/10' },
+  debug: { icon: Bug, color: 'text-muted-foreground', bg: 'bg-muted' },
+  info: { icon: Info, color: 'text-status-info', bg: 'bg-status-info/10' },
+  warn: { icon: AlertTriangle, color: 'text-status-warning', bg: 'bg-status-warning/10' },
+  error: { icon: AlertCircle, color: 'text-status-error', bg: 'bg-status-error/10' },
 };
 
 const levelOptions = [

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -111,10 +111,10 @@ export default function Home() {
       <>
         <PageHeader title="Discovery Feed" description="Review and approve artist recommendations" />
         <div className="text-center py-16">
-          <p className="text-red-400 mb-4">Failed to load feed. Please try again.</p>
+          <p className="text-destructive mb-4">Failed to load feed. Please try again.</p>
           <button
             onClick={() => refetch()}
-            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors"
+            className="px-4 py-2 bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg transition-colors"
           >
             Retry
           </button>

--- a/apps/web/src/app/queue/page.tsx
+++ b/apps/web/src/app/queue/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
 import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/layout/page-header';
@@ -195,15 +196,11 @@ export default function QueuePage() {
           </CardContent>
         </Card>
       ) : filteredItems.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-            <Music2 className="h-12 w-12 text-muted-foreground/50 mb-4" />
-            <p className="text-muted-foreground">No {statusFilter} items in the queue</p>
-            <p className="text-sm text-muted-foreground mt-1">
-              Items are added when subscriptions run with &quot;queue&quot; result handling
-            </p>
-          </CardContent>
-        </Card>
+        <EmptyState
+          icon={Music2}
+          title={`No ${statusFilter} items in the queue`}
+          description={'Items are added when subscriptions run with "queue" result handling'}
+        />
       ) : (
         <div className="space-y-2">
           {/* Select all header */}

--- a/apps/web/src/app/queue/page.tsx
+++ b/apps/web/src/app/queue/page.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { EmptyState } from '@/components/ui';
+import { EmptyState, Skeleton } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
 import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/layout/page-header';
@@ -190,11 +190,18 @@ export default function QueuePage() {
 
       {/* Items list */}
       {isLoading ? (
-        <Card>
-          <CardContent className="flex items-center justify-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-          </CardContent>
-        </Card>
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 p-4 rounded-lg border bg-card">
+              <Skeleton className="w-12 h-12 rounded-md" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-1/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+              <Skeleton className="h-6 w-16 rounded-full" />
+            </div>
+          ))}
+        </div>
       ) : filteredItems.length === 0 ? (
         <EmptyState
           icon={Music2}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui';
 import { LoadingOverlay } from '@/components/ui/loading';
 import { useToast } from '@/components/ui/toast';
 import { PageHeader } from '@/components/layout/page-header';
@@ -118,22 +118,18 @@ export default function SearchPage() {
         )}
 
         {!search.isSearching && search.results.length === 0 && search.query && (
-          <Card>
-            <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-              <SearchIcon className="h-12 w-12 text-muted-foreground/50 mb-4" />
-              <p className="text-muted-foreground">No results found</p>
-              <p className="text-sm text-muted-foreground mt-1">Try a different search term</p>
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={SearchIcon}
+            title="No results found"
+            description="Try a different search term"
+          />
         )}
         {!search.isSearching && !search.query && (
-          <Card>
-            <CardContent className="flex flex-col items-center justify-center py-12 text-center">
-              <SearchIcon className="h-12 w-12 text-muted-foreground/50 mb-4" />
-              <p className="text-muted-foreground">Enter a search term</p>
-              <p className="text-sm text-muted-foreground mt-1">Search by artist, album, label, or year</p>
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={SearchIcon}
+            title="Enter a search term"
+            description="Search by artist, album, label, or year"
+          />
         )}
       </LoadingOverlay>
 

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { EmptyState } from '@/components/ui';
+import { EmptyState, Skeleton } from '@/components/ui';
 import { LoadingOverlay } from '@/components/ui/loading';
 import { useToast } from '@/components/ui/toast';
 import { PageHeader } from '@/components/layout/page-header';
@@ -75,6 +75,20 @@ export default function SearchPage() {
       />
 
       <LoadingOverlay isLoading={search.isSearching} text="Searching...">
+        {search.isSearching && search.results.length === 0 && (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4 p-4 rounded-lg border bg-card">
+                <Skeleton className="w-16 h-16 rounded-md flex-shrink-0" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-1/3" />
+                  <Skeleton className="h-3 w-2/3" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
         {search.results.length > 0 && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -262,7 +262,7 @@ export default function NotificationsSettingsPage() {
                           <span className={`text-xs px-2 py-0.5 rounded-full ${
                             channel.isActive 
                               ? 'bg-status-success/20 text-status-success' 
-                              : 'bg-gray-500/20 text-gray-500'
+                              : 'bg-muted-foreground/20 text-muted-foreground'
                           }`}>
                             {channel.isActive ? 'Active' : 'Inactive'}
                           </span>

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast';
 import { Select } from '@/components/ui/select';
@@ -57,6 +58,7 @@ export default function NotificationsSettingsPage() {
   const [showModal, setShowModal] = useState(false);
   const [editingChannel, setEditingChannel] = useState<NotificationChannel | null>(null);
   const [testingId, setTestingId] = useState<number | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<number | null>(null);
 
   // Form state
   const [form, setForm] = useState({
@@ -175,16 +177,18 @@ export default function NotificationsSettingsPage() {
     }
   };
 
-  const handleDelete = async (id: number) => {
-    if (!confirm('Are you sure you want to delete this notification channel?')) return;
-    
-    const { error } = await api.delete(`/api/notifications/channels/${id}`);
+  const handleDeleteClick = (id: number) => setConfirmTarget(id);
+  const confirmDelete = async () => {
+    if (confirmTarget === null) return;
+
+    const { error } = await api.delete(`/api/notifications/channels/${confirmTarget}`);
     if (error) {
       addToast({ type: 'error', title: 'Failed to delete channel', message: error });
     } else {
       addToast({ type: 'success', title: 'Channel deleted' });
       fetchChannels();
     }
+    setConfirmTarget(null);
   };
 
   const handleTest = async (id: number) => {
@@ -302,7 +306,7 @@ export default function NotificationsSettingsPage() {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => handleDelete(channel.id)}
+                        onClick={() => handleDeleteClick(channel.id)}
                         className="text-destructive hover:text-destructive"
                       >
                         <Trash2 className="w-4 h-4" />
@@ -315,6 +319,16 @@ export default function NotificationsSettingsPage() {
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onClose={() => setConfirmTarget(null)}
+        onConfirm={confirmDelete}
+        title="Delete notification channel?"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+      />
 
       {/* Add/Edit Modal */}
       <Modal isOpen={showModal} onClose={() => setShowModal(false)} title={editingChannel ? 'Edit Channel' : 'Add Notification Channel'}>

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { ConfirmDialog } from '@/components/ui';
+import { ConfirmDialog, EmptyState } from '@/components/ui';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/toast';
 import { Select } from '@/components/ui/select';
@@ -239,19 +239,12 @@ export default function NotificationsSettingsPage() {
         {loading ? (
           <div className="text-muted-foreground text-center py-12">Loading...</div>
         ) : channels.length === 0 ? (
-          <Card>
-            <CardContent className="text-center py-12">
-              <Bell className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
-              <h3 className="text-lg font-medium mb-2">No Notification Channels</h3>
-              <p className="text-muted-foreground mb-4">
-                Add a notification channel to receive alerts about subscriptions, artist additions, and more.
-              </p>
-              <Button onClick={openAddModal}>
-                <Plus className="w-4 h-4 mr-2" />
-                Add Your First Channel
-              </Button>
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={Bell}
+            title="No Notification Channels"
+            description="Add a notification channel to receive alerts about subscriptions, artist additions, and more."
+            action={{ label: 'Add Your First Channel', onClick: openAddModal }}
+          />
         ) : (
           <div className="grid gap-4">
             {channels.map(channel => {

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -261,7 +261,7 @@ export default function NotificationsSettingsPage() {
                           <h4 className="font-medium">{channel.name}</h4>
                           <span className={`text-xs px-2 py-0.5 rounded-full ${
                             channel.isActive 
-                              ? 'bg-green-500/20 text-green-500' 
+                              ? 'bg-status-success/20 text-status-success' 
                               : 'bg-gray-500/20 text-gray-500'
                           }`}>
                             {channel.isActive ? 'Active' : 'Inactive'}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -270,7 +270,7 @@ export default function SettingsPage() {
                           }`}
                         >
                           <span
-                            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                            className={`inline-block h-4 w-4 transform rounded-full bg-foreground transition-transform ${
                               getValue(setting.key, setting.defaultValue) ? 'translate-x-6' : 'translate-x-1'
                             }`}
                           />

--- a/apps/web/src/app/subscriptions/[id]/page.tsx
+++ b/apps/web/src/app/subscriptions/[id]/page.tsx
@@ -168,11 +168,11 @@ export default function SubscriptionDetailPage() {
       pending: 'bg-status-warning/20 text-status-warning',
       queued: 'bg-status-info/20 text-status-info',
       added: 'bg-status-success/20 text-status-success',
-      skipped: 'bg-gray-500/20 text-gray-500',
+      skipped: 'bg-muted-foreground/20 text-muted-foreground',
       failed: 'bg-status-error/20 text-status-error',
       rejected: 'bg-status-error/20 text-status-error',
     };
-    return <Badge className={colors[status] || 'bg-gray-500/20'}>{status}</Badge>;
+    return <Badge className={colors[status] || 'bg-muted-foreground/20'}>{status}</Badge>;
   };
 
   if (isLoading) {

--- a/apps/web/src/app/subscriptions/[id]/page.tsx
+++ b/apps/web/src/app/subscriptions/[id]/page.tsx
@@ -156,21 +156,21 @@ export default function SubscriptionDetailPage() {
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'completed': return <CheckCircle className="h-4 w-4 text-green-500" />;
-      case 'failed': return <XCircle className="h-4 w-4 text-red-500" />;
-      case 'running': return <RefreshCw className="h-4 w-4 text-blue-500 animate-spin" />;
+      case 'completed': return <CheckCircle className="h-4 w-4 text-status-success" />;
+      case 'failed': return <XCircle className="h-4 w-4 text-status-error" />;
+      case 'running': return <RefreshCw className="h-4 w-4 text-status-info animate-spin" />;
       default: return <Clock className="h-4 w-4 text-muted-foreground" />;
     }
   };
 
   const getResultStatusBadge = (status: string) => {
     const colors: Record<string, string> = {
-      pending: 'bg-yellow-500/20 text-yellow-500',
-      queued: 'bg-blue-500/20 text-blue-500',
-      added: 'bg-green-500/20 text-green-500',
+      pending: 'bg-status-warning/20 text-status-warning',
+      queued: 'bg-status-info/20 text-status-info',
+      added: 'bg-status-success/20 text-status-success',
       skipped: 'bg-gray-500/20 text-gray-500',
-      failed: 'bg-red-500/20 text-red-500',
-      rejected: 'bg-red-500/20 text-red-500',
+      failed: 'bg-status-error/20 text-status-error',
+      rejected: 'bg-status-error/20 text-status-error',
     };
     return <Badge className={colors[status] || 'bg-gray-500/20'}>{status}</Badge>;
   };
@@ -348,7 +348,7 @@ export default function SubscriptionDetailPage() {
                             {processingResultId === result.id ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
                             ) : (
-                              <CheckCircle className="h-4 w-4 text-green-500" />
+                              <CheckCircle className="h-4 w-4 text-status-success" />
                             )}
                           </Button>
                           <Button 
@@ -357,7 +357,7 @@ export default function SubscriptionDetailPage() {
                             onClick={() => handleReject(result.id)}
                             disabled={processingResultId === result.id}
                           >
-                            <XCircle className="h-4 w-4 text-red-500" />
+                            <XCircle className="h-4 w-4 text-status-error" />
                           </Button>
                         </>
                       )}

--- a/apps/web/src/app/subscriptions/[id]/page.tsx
+++ b/apps/web/src/app/subscriptions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Tabs, Tab } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
 import { PageHeader } from '@/components/layout/page-header';
 import { api } from '@/lib/api';
@@ -202,20 +203,10 @@ export default function SubscriptionDetailPage() {
       </PageHeader>
 
       {/* Tabs */}
-      <div className="flex gap-2 mb-6">
-        <Button
-          variant={activeTab === 'runs' ? 'default' : 'outline'}
-          onClick={() => { setActiveTab('runs'); setSelectedRun(null); }}
-        >
-          Run History ({runs.length})
-        </Button>
-        <Button
-          variant={activeTab === 'results' ? 'default' : 'outline'}
-          onClick={() => { setActiveTab('results'); setSelectedRun(null); }}
-        >
-          All Results ({Object.values(statusCounts).reduce((a, b) => a + b, 0)})
-        </Button>
-      </div>
+      <Tabs value={activeTab} onChange={(v) => { setActiveTab(v as 'runs' | 'results'); setSelectedRun(null); }} className="mb-6">
+        <Tab value="runs" label="Run History" badge={runs.length} />
+        <Tab value="results" label="All Results" badge={Object.values(statusCounts).reduce((a, b) => a + b, 0)} />
+      </Tabs>
 
       {activeTab === 'runs' && !selectedRun && (
         <div className="space-y-4">

--- a/apps/web/src/app/subscriptions/page.tsx
+++ b/apps/web/src/app/subscriptions/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui';
 import { useToast } from '@/components/ui/toast';
 import { PageHeader } from '@/components/layout/page-header';
 import { useAuth } from '@/lib/auth';
@@ -47,6 +48,7 @@ export default function SubscriptionsPage() {
   const [showModal, setShowModal] = useState(false);
   const [editingSubscription, setEditingSubscription] = useState<Subscription | null>(null);
   const [runningId, setRunningId] = useState<number | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<number | null>(null);
 
   // ============================================================================
   // Handlers
@@ -80,15 +82,16 @@ export default function SubscriptionsPage() {
     setShowModal(true);
   };
 
-  const handleDelete = async (id: number) => {
-    if (!confirm('Delete this subscription?')) return;
-
+  const handleDeleteClick = (id: number) => setConfirmTarget(id);
+  const confirmDelete = async () => {
+    if (confirmTarget === null) return;
     try {
-      await deleteMutation.mutateAsync(id);
+      await deleteMutation.mutateAsync(confirmTarget);
       addToast({ type: 'success', title: 'Subscription deleted' });
     } catch {
       addToast({ type: 'error', title: 'Failed to delete subscription' });
     }
+    setConfirmTarget(null);
   };
 
   const handleSave = async (data: {
@@ -196,11 +199,21 @@ export default function SubscriptionsPage() {
               onRun={handleRun}
               onToggle={handleToggle}
               onEdit={handleEdit}
-              onDelete={handleDelete}
+              onDelete={handleDeleteClick}
             />
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onClose={() => setConfirmTarget(null)}
+        onConfirm={confirmDelete}
+        title="Delete subscription?"
+        description="This action cannot be undone."
+        confirmLabel="Delete"
+        variant="destructive"
+      />
 
       {/* Form Modal */}
       <SubscriptionFormModal

--- a/apps/web/src/app/users/page.tsx
+++ b/apps/web/src/app/users/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui';
 import { Input } from '@/components/ui/input';
 import { Modal, ModalFooter } from '@/components/ui/modal';
 import { useToast } from '@/components/ui/toast';
@@ -50,6 +51,7 @@ export default function UsersPage() {
   const [passwordForm, setPasswordForm] = useState({ current: '', new: '', confirm: '' });
   const [createForm, setCreateForm] = useState({ username: '', password: '', displayName: '', email: '', role: 'user' as 'admin' | 'user' });
   const [editForm, setEditForm] = useState({ displayName: '', email: '', role: 'user' as 'admin' | 'user', isActive: true, password: '' });
+  const [confirmTarget, setConfirmTarget] = useState<number | null>(null);
 
   // Fetch users with React Query (only for admins)
   const { data: usersData, isLoading, isFetching } = useQuery({
@@ -133,17 +135,19 @@ export default function UsersPage() {
     }
   };
 
-  const handleDeleteUser = async (userId: number) => {
-    if (!confirm('Are you sure you want to delete this user? This will delete all their data.')) return;
-    
-    const { error } = await api.delete(`/api/admin/users/${userId}`);
-    
+  const handleDeleteClick = (userId: number) => setConfirmTarget(userId);
+  const confirmDelete = async () => {
+    if (confirmTarget === null) return;
+
+    const { error } = await api.delete(`/api/admin/users/${confirmTarget}`);
+
     if (error) {
       addToast({ type: 'error', title: 'Failed to delete user', message: error });
     } else {
       addToast({ type: 'success', title: 'User deleted' });
       queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
     }
+    setConfirmTarget(null);
   };
 
   const openEditModal = (u: UserData) => {
@@ -282,7 +286,7 @@ export default function UsersPage() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={() => handleDeleteUser(u.id)}
+                          onClick={() => handleDeleteClick(u.id)}
                           title="Delete user"
                         >
                           <Trash2 className="h-4 w-4 text-destructive" />
@@ -296,6 +300,16 @@ export default function UsersPage() {
           </CardContent>
         </Card>
       )}
+
+      <ConfirmDialog
+        open={confirmTarget !== null}
+        onClose={() => setConfirmTarget(null)}
+        onConfirm={confirmDelete}
+        title="Delete user?"
+        description="This will permanently delete the user and all their data."
+        confirmLabel="Delete"
+        variant="destructive"
+      />
 
       {/* Change Password Modal */}
       <Modal

--- a/apps/web/src/components/feed/FeedCard.tsx
+++ b/apps/web/src/components/feed/FeedCard.tsx
@@ -34,6 +34,8 @@ export interface FeedCardProps {
   tags?: string[] | null;
   listeners?: number | null;
   subscriptionName?: string | null;
+  /** Position index for staggered entrance animation */
+  index?: number;
 }
 
 export function FeedCard({
@@ -47,6 +49,7 @@ export function FeedCard({
   tags,
   listeners,
   subscriptionName,
+  index = 0,
 }: FeedCardProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [isTouched, setIsTouched] = useState(false);
@@ -60,6 +63,10 @@ export function FeedCard({
   const hasSource = subscriptionName !== null && subscriptionName !== undefined;
 
   return (
+    <div
+      style={{ animationDelay: `${Math.min(index * 50, 500)}ms` }}
+      className="animate-fade-in opacity-0 [animation-fill-mode:forwards] motion-reduce:animate-none motion-reduce:opacity-100"
+    >
     <div
       className={cn(
         'relative group rounded-card overflow-hidden bg-card transition-all duration-300 hover:shadow-elevation-2',
@@ -172,6 +179,7 @@ export function FeedCard({
           </div>
         )}
       </div>
+    </div>
     </div>
   );
 }

--- a/apps/web/src/components/feed/FeedGrid.test.tsx
+++ b/apps/web/src/components/feed/FeedGrid.test.tsx
@@ -17,6 +17,12 @@ vi.mock('next/link', () => ({
   },
 }));
 
+// Mock Next.js navigation
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 // Mock IntersectionObserver (jsdom doesn't support it)
 const mockObserve = vi.fn();
 const mockUnobserve = vi.fn();
@@ -103,7 +109,7 @@ describe('FeedGrid', () => {
 
     expect(screen.getByText(/No recommendations yet/)).toBeInTheDocument();
     expect(screen.getByText(/Set up subscriptions/)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Set Up Subscriptions/i })).toHaveAttribute('href', '/subscriptions');
+    expect(screen.getByRole('button', { name: /Set Up Subscriptions/i })).toBeInTheDocument();
   });
 
   it('shows loading spinner when loading', () => {

--- a/apps/web/src/components/feed/FeedGrid.tsx
+++ b/apps/web/src/components/feed/FeedGrid.tsx
@@ -97,7 +97,7 @@ export function FeedGrid({
         <div ref={sentinelRef} className="h-10 mt-4">
           {isLoading && (
             <div data-testid="loading-spinner" className="flex justify-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
             </div>
           )}
         </div>

--- a/apps/web/src/components/feed/FeedGrid.tsx
+++ b/apps/web/src/components/feed/FeedGrid.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { EmptyState } from '@/components/ui';
+import { EmptyState, Skeleton } from '@/components/ui';
 import { FeedCard } from './FeedCard';
 import Calendar from 'lucide-react/dist/esm/icons/calendar';
 import type { FeedItem } from '@/lib/hooks';
@@ -55,6 +55,19 @@ export function FeedGrid({
   }, [hasMore, isLoading, onLoadMore]);
 
   const router = useRouter();
+
+  // Skeleton loading state
+  if (isLoading && items.length === 0) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="aspect-square">
+            <Skeleton className="w-full h-full rounded-lg" />
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   // Empty state
   if (items.length === 0 && !isLoading) {

--- a/apps/web/src/components/feed/FeedGrid.tsx
+++ b/apps/web/src/components/feed/FeedGrid.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { EmptyState } from '@/components/ui';
 import { FeedCard } from './FeedCard';
+import Calendar from 'lucide-react/dist/esm/icons/calendar';
 import type { FeedItem } from '@/lib/hooks';
 
 export interface FeedGridProps {
@@ -52,19 +54,17 @@ export function FeedGrid({
     };
   }, [hasMore, isLoading, onLoadMore]);
 
+  const router = useRouter();
+
   // Empty state
   if (items.length === 0 && !isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <p className="text-gray-400 text-lg mb-4">No recommendations yet</p>
-        <p className="text-gray-500 mb-6">Set up subscriptions to start discovering artists</p>
-        <Link
-          href="/subscriptions"
-          className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors"
-        >
-          Set Up Subscriptions
-        </Link>
-      </div>
+      <EmptyState
+        icon={Calendar}
+        title="No recommendations yet"
+        description="Set up subscriptions to start discovering artists"
+        action={{ label: 'Set Up Subscriptions', onClick: () => router.push('/subscriptions') }}
+      />
     );
   }
 

--- a/apps/web/src/components/feed/FeedGrid.tsx
+++ b/apps/web/src/components/feed/FeedGrid.tsx
@@ -88,7 +88,7 @@ export function FeedGrid({
         data-testid="feed-grid"
         className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
       >
-        {items.map((item) => (
+        {items.map((item, i) => (
           <FeedCard
             key={item.id}
             id={item.id}
@@ -101,6 +101,7 @@ export function FeedGrid({
             tags={item.tags}
             listeners={item.listeners}
             subscriptionName={item.subscriptionName}
+            index={i}
           />
         ))}
       </div>

--- a/apps/web/src/components/feed/StatsBar.tsx
+++ b/apps/web/src/components/feed/StatsBar.tsx
@@ -5,7 +5,7 @@ export interface StatsBarProps {
 
 export function StatsBar({ pending, addedToday }: StatsBarProps) {
   return (
-    <div className="text-sm text-gray-400 mb-6">
+    <div className="text-sm text-muted-foreground mb-6">
       <span>{pending} pending</span>
       <span className="mx-2">•</span>
       <span>{addedToday} added today</span>

--- a/apps/web/src/components/layout/mobile-nav.tsx
+++ b/apps/web/src/components/layout/mobile-nav.tsx
@@ -59,7 +59,7 @@ export function MobileNav() {
     <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-t border-border md:hidden safe-area-inset-bottom">
       {/* Offline indicator */}
       {isOffline && (
-        <div className="bg-status-warning/90 text-yellow-950 text-xs text-center py-1 px-2">
+        <div className="bg-status-warning/90 text-foreground text-xs text-center py-1 px-2">
           You&apos;re offline
           {pendingActionsCount > 0 && ` • ${pendingActionsCount} pending`}
         </div>

--- a/apps/web/src/components/layout/mobile-nav.tsx
+++ b/apps/web/src/components/layout/mobile-nav.tsx
@@ -1,13 +1,20 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import Calendar from 'lucide-react/dist/esm/icons/calendar';
+import Compass from 'lucide-react/dist/esm/icons/compass';
+import Download from 'lucide-react/dist/esm/icons/download';
 import Home from 'lucide-react/dist/esm/icons/home';
 import Library from 'lucide-react/dist/esm/icons/library';
 import ListTodo from 'lucide-react/dist/esm/icons/list-todo';
+import MoreHorizontal from 'lucide-react/dist/esm/icons/more-horizontal';
+import Plug from 'lucide-react/dist/esm/icons/plug';
 import Search from 'lucide-react/dist/esm/icons/search';
+import SettingsIcon from 'lucide-react/dist/esm/icons/settings';
 import { useOfflineStatus } from '@/lib/use-offline-status';
+import { BottomSheet } from '@/components/ui/bottom-sheet';
 
 interface NavItem {
   href: string;
@@ -16,13 +23,16 @@ interface NavItem {
   badge?: number;
 }
 
+const MORE_PATHS = ['/subscriptions', '/discover', '/downloads', '/connections', '/settings'];
+
 export function MobileNav() {
   const pathname = usePathname();
   const { isOffline, pendingActionsCount } = useOfflineStatus();
+  const [moreOpen, setMoreOpen] = useState(false);
 
   const navItems: NavItem[] = [
     {
-      href: '/dashboard',
+      href: '/',
       label: 'Home',
       icon: <Home className="h-5 w-5" />,
     },
@@ -41,56 +51,93 @@ export function MobileNav() {
       label: 'Library',
       icon: <Library className="h-5 w-5" />,
     },
-    {
-      href: '/subscriptions',
-      label: 'Subs',
-      icon: <Calendar className="h-5 w-5" />,
-    },
   ];
 
   const isActive = (href: string) => {
-    if (href === '/dashboard') {
-      return pathname === '/dashboard' || pathname === '/';
+    if (href === '/') {
+      return pathname === '/' || pathname === '/dashboard';
     }
     return pathname.startsWith(href);
   };
 
+  const isMoreActive = MORE_PATHS.some((p) => pathname.startsWith(p));
+
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-t border-border md:hidden safe-area-inset-bottom">
-      {/* Offline indicator */}
-      {isOffline && (
-        <div className="bg-status-warning/90 text-foreground text-xs text-center py-1 px-2">
-          You&apos;re offline
-          {pendingActionsCount > 0 && ` • ${pendingActionsCount} pending`}
+    <>
+      <nav className="fixed bottom-0 left-0 right-0 z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 border-t border-border md:hidden safe-area-inset-bottom">
+        {/* Offline indicator */}
+        {isOffline && (
+          <div className="bg-status-warning/90 text-foreground text-xs text-center py-1 px-2">
+            You&apos;re offline
+            {pendingActionsCount > 0 && ` • ${pendingActionsCount} pending`}
+          </div>
+        )}
+        
+        <div className="flex justify-around items-center py-2 px-1">
+          {navItems.map((item) => {
+            const active = isActive(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex flex-col items-center justify-center min-w-[56px] py-1 px-2 rounded-lg transition-colors ${
+                  active 
+                    ? 'text-primary' 
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                <span className="relative">
+                  {item.icon}
+                  {item.badge && item.badge > 0 && (
+                    <span className="absolute -top-1 -right-1 bg-primary text-primary-foreground text-xs rounded-full h-4 min-w-[16px] flex items-center justify-center px-1">
+                      {item.badge > 99 ? '99+' : item.badge}
+                    </span>
+                  )}
+                </span>
+                <span className="text-[10px] mt-0.5 font-medium">{item.label}</span>
+              </Link>
+            );
+          })}
+
+          {/* More tab */}
+          <button
+            onClick={() => setMoreOpen(true)}
+            className={`flex flex-col items-center justify-center min-w-[56px] py-1 px-2 rounded-lg transition-colors ${
+              isMoreActive
+                ? 'text-primary'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <MoreHorizontal className="h-5 w-5" />
+            <span className="text-[10px] mt-0.5 font-medium">More</span>
+          </button>
         </div>
-      )}
-      
-      <div className="flex justify-around items-center py-2 px-1">
-        {navItems.map((item) => {
-          const active = isActive(item.href);
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`flex flex-col items-center justify-center min-w-[56px] py-1 px-2 rounded-lg transition-colors ${
-                active 
-                  ? 'text-primary' 
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              <span className="relative">
-                {item.icon}
-                {item.badge && item.badge > 0 && (
-                  <span className="absolute -top-1 -right-1 bg-primary text-primary-foreground text-xs rounded-full h-4 min-w-[16px] flex items-center justify-center px-1">
-                    {item.badge > 99 ? '99+' : item.badge}
-                  </span>
-                )}
-              </span>
-              <span className="text-[10px] mt-0.5 font-medium">{item.label}</span>
-            </Link>
-          );
-        })}
-      </div>
-    </nav>
+      </nav>
+
+      <BottomSheet isOpen={moreOpen} onClose={() => setMoreOpen(false)} title="More">
+        <div className="flex flex-col gap-1">
+          <Link href="/subscriptions" onClick={() => setMoreOpen(false)} className="flex items-center gap-3 px-2 py-3 rounded-lg hover:bg-accent transition-colors">
+            <Calendar className="w-5 h-5" />
+            <span>Subscriptions</span>
+          </Link>
+          <Link href="/discover" onClick={() => setMoreOpen(false)} className="flex items-center gap-3 px-2 py-3 rounded-lg hover:bg-accent transition-colors">
+            <Compass className="w-5 h-5" />
+            <span>Discover</span>
+          </Link>
+          <Link href="/downloads" onClick={() => setMoreOpen(false)} className="flex items-center gap-3 px-2 py-3 rounded-lg hover:bg-accent transition-colors">
+            <Download className="w-5 h-5" />
+            <span>Downloads</span>
+          </Link>
+          <Link href="/connections" onClick={() => setMoreOpen(false)} className="flex items-center gap-3 px-2 py-3 rounded-lg hover:bg-accent transition-colors">
+            <Plug className="w-5 h-5" />
+            <span>Connections</span>
+          </Link>
+          <Link href="/settings" onClick={() => setMoreOpen(false)} className="flex items-center gap-3 px-2 py-3 rounded-lg hover:bg-accent transition-colors">
+            <SettingsIcon className="w-5 h-5" />
+            <span>Settings</span>
+          </Link>
+        </div>
+      </BottomSheet>
+    </>
   );
 }

--- a/apps/web/src/components/settings/ai-settings.tsx
+++ b/apps/web/src/components/settings/ai-settings.tsx
@@ -152,7 +152,7 @@ export function AISettings() {
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-foreground transition-transform ${
                   settings.openaiEnabled ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -233,7 +233,7 @@ export function AISettings() {
               }`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                className={`inline-block h-4 w-4 transform rounded-full bg-foreground transition-transform ${
                   settings.anthropicEnabled ? 'translate-x-6' : 'translate-x-1'
                 }`}
               />
@@ -269,9 +269,9 @@ export function AISettings() {
         </div>
 
         {/* Info */}
-        <div className="rounded-lg bg-blue-50 dark:bg-blue-950/50 p-4 text-sm">
-          <p className="font-medium text-blue-900 dark:text-blue-100">About AI Recommendations</p>
-          <p className="mt-1 text-blue-800 dark:text-blue-200">
+        <div className="rounded-lg bg-status-info/10 p-4 text-sm">
+          <p className="font-medium text-status-info">About AI Recommendations</p>
+          <p className="mt-1 text-status-info">
             AI recommendations analyze your library and listening patterns to suggest new artists.
             Configure AI recommendation strategy per-subscription when creating an AI Recommendations subscription.
           </p>

--- a/apps/web/src/components/settings/sso-settings.tsx
+++ b/apps/web/src/components/settings/sso-settings.tsx
@@ -324,7 +324,7 @@ export function SSOSettings() {
                     } ${!isSaved ? 'opacity-50 cursor-not-allowed' : ''}`}
                   >
                     <span
-                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      className={`inline-block h-4 w-4 transform rounded-full bg-foreground transition-transform ${
                         isEnabled ? 'translate-x-6' : 'translate-x-1'
                       }`}
                     />
@@ -452,9 +452,9 @@ export function SSOSettings() {
         })}
 
         {/* Info Box */}
-        <div className="rounded-lg bg-blue-50 dark:bg-blue-950/50 p-4 text-sm">
-          <p className="font-medium text-blue-900 dark:text-blue-100">About Single Sign-On</p>
-          <p className="mt-1 text-blue-800 dark:text-blue-200">
+        <div className="rounded-lg bg-status-info/10 p-4 text-sm">
+          <p className="font-medium text-status-info">About Single Sign-On</p>
+          <p className="mt-1 text-status-info">
             SSO allows users to authenticate using external identity providers. Enable a provider and configure its settings to allow users to sign in with their existing credentials.
           </p>
         </div>

--- a/apps/web/src/components/slskd/SearchModal.tsx
+++ b/apps/web/src/components/slskd/SearchModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Image from 'next/image';
 import { Modal } from '@/components/ui/modal';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -303,9 +304,9 @@ export function SlskdSearchModal({ isOpen, onClose, artistName, artistImage }: S
     >
       {/* Header with artist info */}
       <div className="flex items-center gap-4 mb-6">
-        <div className="w-16 h-16 rounded-lg overflow-hidden bg-muted flex items-center justify-center flex-shrink-0">
+        <div className="relative w-16 h-16 rounded-lg overflow-hidden bg-muted flex items-center justify-center flex-shrink-0">
           {artistImage ? (
-            <img src={artistImage} alt={artistName} className="w-full h-full object-cover" />
+            <Image src={artistImage} alt={artistName} fill className="object-cover" unoptimized />
           ) : (
             <Music className="h-8 w-8 text-muted-foreground" />
           )}

--- a/apps/web/src/components/subscriptions/SubscriptionFormModal.tsx
+++ b/apps/web/src/components/subscriptions/SubscriptionFormModal.tsx
@@ -555,7 +555,7 @@ export function SubscriptionFormModal({
               <label className="text-sm font-medium">
                 Tag
                 {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'tag') && (
-                  <span className="text-red-500 ml-1">*</span>
+                  <span className="text-destructive ml-1">*</span>
                 )}
               </label>
               <Input
@@ -563,7 +563,7 @@ export function SubscriptionFormModal({
                 onChange={(e) => setForm({ ...form, tag: e.target.value })}
                 placeholder="e.g., rock, metal, jazz"
               />
-              {validationErrors.tag && <p className="text-xs text-red-600 mt-1">{validationErrors.tag}</p>}
+              {validationErrors.tag && <p className="text-xs text-destructive mt-1">{validationErrors.tag}</p>}
             </div>
           )}
 
@@ -573,7 +573,7 @@ export function SubscriptionFormModal({
               <label className="text-sm font-medium">
                 Playlist ID
                 {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'playlistId') && (
-                  <span className="text-red-500 ml-1">*</span>
+                  <span className="text-destructive ml-1">*</span>
                 )}
               </label>
               <Input
@@ -582,7 +582,7 @@ export function SubscriptionFormModal({
                 placeholder="Spotify playlist ID"
               />
               {validationErrors.playlistId && (
-                <p className="text-xs text-red-600 mt-1">{validationErrors.playlistId}</p>
+                <p className="text-xs text-destructive mt-1">{validationErrors.playlistId}</p>
               )}
             </div>
           )}
@@ -605,7 +605,7 @@ export function SubscriptionFormModal({
                 <label className="text-sm font-medium">
                   Playlist URL
                   {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'publicPlaylistUrl') && (
-                    <span className="text-red-500 ml-1">*</span>
+                    <span className="text-destructive ml-1">*</span>
                   )}
                 </label>
                 <Input
@@ -617,7 +617,7 @@ export function SubscriptionFormModal({
                   Paste any public Spotify playlist URL (no login required)
                 </p>
                 {validationErrors.publicPlaylistUrl && (
-                  <p className="text-xs text-red-600 mt-1">{validationErrors.publicPlaylistUrl}</p>
+                  <p className="text-xs text-destructive mt-1">{validationErrors.publicPlaylistUrl}</p>
                 )}
               </div>
               <div className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
@@ -626,7 +626,7 @@ export function SubscriptionFormModal({
                   id="discoverAlbums"
                   checked={form.discoverAlbums}
                   onChange={(e) => setForm({ ...form, discoverAlbums: e.target.checked })}
-                  className="h-4 w-4 rounded border-gray-300"
+                  className="h-4 w-4 rounded border-input"
                 />
                 <label htmlFor="discoverAlbums" className="text-sm">
                   <span className="font-medium">Discover Albums</span>
@@ -642,7 +642,7 @@ export function SubscriptionFormModal({
                     id="includeAllArtists"
                     checked={form.includeAllArtists}
                     onChange={(e) => setForm({ ...form, includeAllArtists: e.target.checked })}
-                    className="h-4 w-4 rounded border-gray-300"
+                    className="h-4 w-4 rounded border-input"
                   />
                   <label htmlFor="includeAllArtists" className="text-sm">
                     <span className="font-medium">Include Featured Artists</span>
@@ -661,7 +661,7 @@ export function SubscriptionFormModal({
               <label className="text-sm font-medium">
                 Playlist ID
                 {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'playlistId') && (
-                  <span className="text-red-500 ml-1">*</span>
+                  <span className="text-destructive ml-1">*</span>
                 )}
               </label>
               <Input
@@ -670,7 +670,7 @@ export function SubscriptionFormModal({
                 placeholder="Deezer playlist ID"
               />
               {validationErrors.playlistId && (
-                <p className="text-xs text-red-600 mt-1">{validationErrors.playlistId}</p>
+                <p className="text-xs text-destructive mt-1">{validationErrors.playlistId}</p>
               )}
             </div>
           )}
@@ -681,7 +681,7 @@ export function SubscriptionFormModal({
               <label className="text-sm font-medium">
                 Playlist ID
                 {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'playlistId') && (
-                  <span className="text-red-500 ml-1">*</span>
+                  <span className="text-destructive ml-1">*</span>
                 )}
               </label>
               <Input
@@ -690,7 +690,7 @@ export function SubscriptionFormModal({
                 placeholder="TIDAL playlist UUID"
               />
               {validationErrors.playlistId && (
-                <p className="text-xs text-red-600 mt-1">{validationErrors.playlistId}</p>
+                <p className="text-xs text-destructive mt-1">{validationErrors.playlistId}</p>
               )}
             </div>
           )}
@@ -756,7 +756,7 @@ export function SubscriptionFormModal({
               <label className="text-sm font-medium">
                 Playlist ID
                 {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'listenbrainzPlaylistId') && (
-                  <span className="text-red-500 ml-1">*</span>
+                  <span className="text-destructive ml-1">*</span>
                 )}
               </label>
               <Input
@@ -768,7 +768,7 @@ export function SubscriptionFormModal({
                 The playlist MBID from the ListenBrainz playlist URL.
               </p>
               {validationErrors.listenbrainzPlaylistId && (
-                <p className="text-xs text-red-600 mt-1">{validationErrors.listenbrainzPlaylistId}</p>
+                <p className="text-xs text-destructive mt-1">{validationErrors.listenbrainzPlaylistId}</p>
               )}
             </div>
           )}
@@ -780,7 +780,7 @@ export function SubscriptionFormModal({
                 <label className="text-sm font-medium">
                   Seed Artist{' '}
                   {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'listenbrainzSeedMbid') && (
-                    <span className="text-red-500">*</span>
+                    <span className="text-destructive">*</span>
                   )}
                 </label>
                 <div className="relative">
@@ -842,7 +842,7 @@ export function SubscriptionFormModal({
                   )}
 
                 {validationErrors.listenbrainzSeedMbid && (
-                  <p className="text-xs text-red-600 mt-1">{validationErrors.listenbrainzSeedMbid}</p>
+                  <p className="text-xs text-destructive mt-1">{validationErrors.listenbrainzSeedMbid}</p>
                 )}
               </div>
 
@@ -889,7 +889,7 @@ export function SubscriptionFormModal({
                 <label className="text-sm font-medium">
                   Label ID
                   {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'labelId') && (
-                    <span className="text-red-500 ml-1">*</span>
+                    <span className="text-destructive ml-1">*</span>
                   )}
                 </label>
                 <Input
@@ -900,7 +900,7 @@ export function SubscriptionFormModal({
                 <p className="text-xs text-muted-foreground mt-1">
                   Find the label ID from the Discogs URL: discogs.com/label/<strong>1234</strong>-Label-Name
                 </p>
-                {validationErrors.labelId && <p className="text-xs text-red-600 mt-1">{validationErrors.labelId}</p>}
+                {validationErrors.labelId && <p className="text-xs text-destructive mt-1">{validationErrors.labelId}</p>}
               </div>
               <div>
                 <label className="text-sm font-medium">Label Name (for display)</label>
@@ -919,7 +919,7 @@ export function SubscriptionFormModal({
               <label className="text-sm font-medium">
                 Style/Genre
                 {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'discogsStyle') && (
-                  <span className="text-red-500 ml-1">*</span>
+                  <span className="text-destructive ml-1">*</span>
                 )}
               </label>
               <Select
@@ -945,7 +945,7 @@ export function SubscriptionFormModal({
                 ]}
               />
               {validationErrors.discogsStyle && (
-                <p className="text-xs text-red-600 mt-1">{validationErrors.discogsStyle}</p>
+                <p className="text-xs text-destructive mt-1">{validationErrors.discogsStyle}</p>
               )}
             </div>
           )}
@@ -957,7 +957,7 @@ export function SubscriptionFormModal({
                 <label className="text-sm font-medium">
                   Tag
                   {REQUIRED_FIELDS[form.type]?.some((r) => r.field === 'bandcampTag') && (
-                    <span className="text-red-500 ml-1">*</span>
+                    <span className="text-destructive ml-1">*</span>
                   )}
                 </label>
                 <Input
@@ -967,7 +967,7 @@ export function SubscriptionFormModal({
                 />
                 <p className="text-xs text-muted-foreground mt-1">Browse tags at bandcamp.com/tags</p>
                 {validationErrors.bandcampTag && (
-                  <p className="text-xs text-red-600 mt-1">{validationErrors.bandcampTag}</p>
+                  <p className="text-xs text-destructive mt-1">{validationErrors.bandcampTag}</p>
                 )}
               </div>
               {form.type === 'bandcamp_tag' && (

--- a/apps/web/src/components/ui/bottom-sheet.tsx
+++ b/apps/web/src/components/ui/bottom-sheet.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+import X from 'lucide-react/dist/esm/icons/x';
+
+interface BottomSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetProps) {
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handleKey);
+    document.body.style.overflow = 'hidden';
+    return () => { document.removeEventListener('keydown', handleKey); document.body.style.overflow = 'unset'; };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 md:hidden">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="absolute bottom-0 left-0 right-0 bg-card rounded-t-2xl shadow-lg animate-slide-up pb-safe"
+      >
+        {/* Handle bar */}
+        <div className="flex justify-center pt-3 pb-1">
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+        </div>
+        {title && (
+          <div className="flex items-center justify-between px-6 pb-2">
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">{title}</h3>
+            <button onClick={onClose} aria-label="Close" className="p-1 rounded-lg hover:bg-accent">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+        <div className="px-4 pb-6">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -13,9 +13,9 @@ export function Checkbox({ checked, onCheckedChange, className, ...props }: Chec
       type="checkbox"
       checked={checked}
       onChange={(e) => onCheckedChange?.(e.target.checked)}
-      className={`h-4 w-4 rounded border-gray-300 dark:border-gray-600 
+      className={`h-4 w-4 rounded border-input 
         text-primary focus:ring-primary focus:ring-offset-0 
-        dark:bg-gray-800 cursor-pointer ${className || ''}`}
+        bg-muted cursor-pointer ${className || ''}`}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import * as React from 'react';
+import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
+import Info from 'lucide-react/dist/esm/icons/info';
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2';
+import { Modal, ModalFooter } from './modal';
+import { Button } from './button';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'destructive' | 'warning' | 'info';
+  loading?: boolean;
+}
+
+const icons = {
+  destructive: Trash2,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+const iconColors = {
+  destructive: 'text-destructive',
+  warning: 'text-status-warning',
+  info: 'text-status-info',
+};
+
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'destructive',
+  loading = false,
+}: ConfirmDialogProps) {
+  const Icon = icons[variant];
+
+  return (
+    <Modal isOpen={open} onClose={onClose} size="sm">
+      <div className="flex flex-col items-center text-center">
+        <div className={`rounded-full bg-muted p-3 mb-4 ${iconColors[variant]}`}>
+          <Icon className="h-6 w-6" />
+        </div>
+        <h3 className="text-lg font-semibold">{title}</h3>
+        {description && (
+          <p className="mt-2 text-sm text-muted-foreground whitespace-pre-line">{description}</p>
+        )}
+      </div>
+      <ModalFooter className="justify-center">
+        <Button variant="outline" onClick={onClose} disabled={loading}>
+          {cancelLabel}
+        </Button>
+        <Button
+          variant={variant === 'destructive' ? 'destructive' : 'default'}
+          onClick={onConfirm}
+          isLoading={loading}
+        >
+          {confirmLabel}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,4 +1,6 @@
 // UI Component exports
+export { BottomSheet } from './bottom-sheet';
+
 export { Button, buttonVariants } from './button';
 export type { ButtonProps } from './button';
 

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -28,3 +28,4 @@ export { Checkbox } from './checkbox';
 export { ConfirmDialog } from './confirm-dialog';
 
 export { Skeleton, SkeletonText, SkeletonCard } from './skeleton';
+export { Tabs, Tab } from './tabs';

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -25,4 +25,6 @@ export { OfflineIndicator } from './offline-indicator';
 
 export { Checkbox } from './checkbox';
 
+export { ConfirmDialog } from './confirm-dialog';
+
 export { Skeleton, SkeletonText, SkeletonCard } from './skeleton';

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface TabsProps {
+  value: string;
+  onChange: (value: string) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Tabs({ value, onChange, children, className }: TabsProps) {
+  return (
+    <TabsContext.Provider value={{ value, onChange }}>
+      <div className={cn('flex gap-2 border-b', className)} role="tablist">
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}
+
+interface TabProps {
+  value: string;
+  label: string;
+  icon?: React.ReactNode;
+  badge?: number | string;
+  className?: string;
+}
+
+const TabsContext = React.createContext<{ value: string; onChange: (v: string) => void } | null>(null);
+
+function useTabsContext() {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx) throw new Error('Tab must be used within Tabs');
+  return ctx;
+}
+
+export function Tab({ value, label, icon, badge, className }: TabProps) {
+  const { value: selected, onChange } = useTabsContext();
+  const isActive = selected === value;
+
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onChange(value)}
+      className={cn(
+        'px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px',
+        isActive
+          ? 'border-primary text-primary'
+          : 'border-transparent text-muted-foreground hover:text-foreground',
+        className,
+      )}
+    >
+      {icon && <span className="inline-flex mr-2 align-middle">{icon}</span>}
+      {label}
+      {badge != null && <span className="ml-1.5 text-xs text-muted-foreground">({badge})</span>}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -70,10 +70,10 @@ const icons = {
 };
 
 const iconColors = {
-  success: 'text-green-500',
-  error: 'text-red-500',
-  warning: 'text-yellow-500',
-  info: 'text-blue-500',
+  success: 'text-status-success',
+  error: 'text-status-error',
+  warning: 'text-status-warning',
+  info: 'text-status-info',
 };
 
 function ToastContainer({
@@ -84,7 +84,7 @@ function ToastContainer({
   onRemove: (id: string) => void;
 }) {
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+    <div className="fixed bottom-20 md:bottom-4 right-4 z-50 flex flex-col gap-2">
       {toasts.map((toast) => {
         const Icon = icons[toast.type];
         return (

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -58,7 +58,7 @@ const config: Config = {
         width: 'width',
       },
       animation: {
-        'fade-in': 'fadeIn 0.2s ease-out',
+        'fade-in': 'fadeIn 0.4s ease-out',
         'slide-in': 'slideIn 0.2s ease-out',
         'slide-out': 'slideOut 0.2s ease-in',
         'spin-slow': 'spin 2s linear infinite',
@@ -66,8 +66,8 @@ const config: Config = {
       },
       keyframes: {
         fadeIn: {
-          '0%': { opacity: '0' },
-          '100%': { opacity: '1' },
+          '0%': { opacity: '0', transform: 'translateY(8px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
         },
         slideIn: {
           '0%': { transform: 'translateX(-100%)' },

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -63,6 +63,7 @@ const config: Config = {
         'slide-out': 'slideOut 0.2s ease-in',
         'spin-slow': 'spin 2s linear infinite',
         'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+        'slide-up': 'slideUp 0.3s ease-out',
       },
       keyframes: {
         fadeIn: {
@@ -76,6 +77,10 @@ const config: Config = {
         slideOut: {
           '0%': { transform: 'translateX(0)' },
           '100%': { transform: 'translateX(-100%)' },
+        },
+        slideUp: {
+          '0%': { transform: 'translateY(100%)' },
+          '100%': { transform: 'translateY(0)' },
         },
       },
       fontFamily: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@prisma/client": "^5.22.0",
         "bcryptjs": "^2.4.3",
         "bullmq": "^5.25.2",
-        "connect-redis": "^9.0.0",
+        "connect-redis": "7.1.1",
         "cors": "^2.8.5",
         "cron": "^3.1.7",
         "dotenv": "^16.4.5",
@@ -66,6 +66,18 @@
         "tsx": "^4.19.2",
         "typescript": "^5.3.3",
         "vitest": "^4.0.16"
+      }
+    },
+    "apps/api/node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
       }
     },
     "apps/api/node_modules/node-fetch": {
@@ -1437,79 +1449,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
-      }
-    },
-    "node_modules/@redis/bloom": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.11.0.tgz",
-      "integrity": "sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/@redis/client": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
-      "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@node-rs/xxhash": "^1.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@node-rs/xxhash": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@redis/json": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.11.0.tgz",
-      "integrity": "sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/@redis/search": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.11.0.tgz",
-      "integrity": "sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/@redis/time-series": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.11.0.tgz",
-      "integrity": "sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3519,19 +3458,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/connect-redis": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-9.0.0.tgz",
-      "integrity": "sha512-QwzyvUePTMvEzG1hy45gZYw3X3YHrjmEdSkayURlcZft7hqadQ3X39wYkmCqblK2rGlw+XItELYt6GnyG6DEIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "express-session": ">=1",
-        "redis": ">=5"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -7655,23 +7581,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redis": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
-      "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@redis/bloom": "5.11.0",
-        "@redis/client": "5.11.0",
-        "@redis/json": "5.11.0",
-        "@redis/search": "5.11.0",
-        "@redis/time-series": "5.11.0"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/redis-errors": {


### PR DESCRIPTION
## Summary

Comprehensive UX/UI polish pass covering 10 improvement categories from a frontend audit.

### New Components (3)
- **ConfirmDialog** — wraps Modal with destructive/warning/info variants, replaces all `window.confirm()` calls
- **Tabs/Tab** — compound component with underline-style active indicators, replaces 2 ad-hoc implementations
- **BottomSheet** — mobile-only slide-up sheet for the new More menu

### Component Adoption
- **EmptyState** — adopted across 5 pages (was defined but never imported)
- **Select** — replaced 6 raw `<select>` elements in discover page
- **Skeleton** — added content-shaped loading placeholders to 5 data pages
- **Image** — replaced 1 raw `<img>` in SearchModal with Next.js Image

### Color Cleanup (~56 replacements)
- Status colors: `text-green-500` → `text-status-success`, etc. across 5 files
- Structural: `text-red-500` validation → `text-destructive`, `bg-white` toggles → `bg-foreground`, info boxes → semantic tokens
- Added `text-status-*` CSS utilities for theme-aware status text colors

### UX Improvements
- Toast positioning: `bottom-20 md:bottom-4` to clear mobile nav bar
- SSO login: emoji icons (🟠🔑🔐) → proper Lucide icons
- Feed cards: staggered fade-in entrance animation (respects prefers-reduced-motion)
- Connection cards: interactive hover lift + glow
- Mobile nav: Subs tab → More menu with BottomSheet listing all remaining pages
- Mobile nav: Fixed Home route from `/dashboard` to `/`

### Stats
- 33 files changed, +623/−301 lines
- 14 focused commits
- 218/218 tests passing
- Production build clean (`next build` ✓)