### PR TITLE
fix(security): validate URLs before fetch to prevent SSRF (CodeQL #50)

### DIFF
--- a/apps/api/src/services/jellyfin.ts
+++ b/apps/api/src/services/jellyfin.ts
@@ -6,6 +6,7 @@
 
 import { rateLimit } from './rate-limiter.js';
 import { fetchWithTimeout } from '../lib/fetch-with-timeout.js';
+import { validateServiceUrl } from '../lib/validate-service-url.js';
 
 export interface JellyfinConfig {
   jellyfinUrl: string;
@@ -188,7 +189,8 @@ export class JellyfinService {
   private async callApi<T>(config: JellyfinConfig, endpoint: string, params?: Record<string, string>): Promise<T> {
     await rateLimit('jellyfin');
 
-    const url = new URL(endpoint, config.jellyfinUrl);
+    const validatedBase = validateServiceUrl(config.jellyfinUrl, 'Jellyfin');
+    const url = new URL(endpoint, validatedBase);
     if (params) {
       for (const [key, value] of Object.entries(params)) {
         url.searchParams.set(key, value);

--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -11,6 +11,7 @@
 
 import prisma from '../lib/db.js';
 import { fetchWithTimeout } from '../lib/fetch-with-timeout.js';
+import { validateServiceUrl } from '../lib/validate-service-url.js';
 import { createLogger } from '../lib/logger.js';
 
 const log = createLogger('Notifications');
@@ -131,7 +132,8 @@ export class NotificationService {
   ): Promise<void> {
     const embed = this.formatDiscordEmbed(event, payload);
 
-    await fetchWithTimeout(config.webhookUrl, {
+    const validatedUrl = validateServiceUrl(config.webhookUrl, 'Discord webhook');
+    await fetchWithTimeout(validatedUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -157,7 +159,8 @@ export class NotificationService {
       ...payload,
     });
 
-    await fetchWithTimeout(config.url, {
+    const validatedUrl = validateServiceUrl(config.url, 'Webhook');
+    await fetchWithTimeout(validatedUrl, {
       method: config.method || 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/api/src/services/tautulli.ts
+++ b/apps/api/src/services/tautulli.ts
@@ -6,6 +6,7 @@
 
 import { rateLimit } from './rate-limiter.js';
 import { fetchWithTimeout } from '../lib/fetch-with-timeout.js';
+import { validateServiceUrl } from '../lib/validate-service-url.js';
 
 export interface TautulliConfig {
   tautulliUrl: string;
@@ -226,7 +227,8 @@ export class TautulliService {
   ): Promise<TautulliResponse<T>> {
     await rateLimit('tautulli');
 
-    const url = new URL('/api/v2', config.tautulliUrl);
+    const validatedBase = validateServiceUrl(config.tautulliUrl, 'Tautulli');
+    const url = new URL('/api/v2', validatedBase);
     url.searchParams.set('apikey', config.tautulliApiKey);
     url.searchParams.set('cmd', cmd);
     

--- a/apps/api/tests/lib/validate-service-url.test.ts
+++ b/apps/api/tests/lib/validate-service-url.test.ts
@@ -1,0 +1,72 @@
+/**
+ * validateServiceUrl Tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateServiceUrl } from '../../src/lib/validate-service-url.js';
+
+describe('validateServiceUrl', () => {
+  describe('valid URLs', () => {
+    it('accepts http URLs', () => {
+      expect(validateServiceUrl('http://localhost:8080', 'Test')).toBe('http://localhost:8080');
+    });
+
+    it('accepts https URLs', () => {
+      expect(validateServiceUrl('https://example.com', 'Test')).toBe('https://example.com');
+    });
+
+    it('preserves path segments', () => {
+      expect(validateServiceUrl('http://localhost:8080/lidarr', 'Test')).toBe(
+        'http://localhost:8080/lidarr'
+      );
+    });
+
+    it('strips trailing slash', () => {
+      expect(validateServiceUrl('http://localhost:8080/', 'Test')).toBe('http://localhost:8080');
+    });
+
+    it('strips trailing slash from path', () => {
+      expect(validateServiceUrl('http://localhost:8080/lidarr/', 'Test')).toBe(
+        'http://localhost:8080/lidarr'
+      );
+    });
+
+    it('preserves port number', () => {
+      expect(validateServiceUrl('http://192.168.1.100:8686', 'Lidarr')).toBe(
+        'http://192.168.1.100:8686'
+      );
+    });
+  });
+
+  describe('rejected inputs', () => {
+    it('rejects file:// protocol', () => {
+      expect(() => validateServiceUrl('file:///etc/passwd', 'Test')).toThrow(
+        'URL must use http or https protocol'
+      );
+    });
+
+    it('rejects ftp:// protocol', () => {
+      expect(() => validateServiceUrl('ftp://example.com', 'Test')).toThrow(
+        'URL must use http or https protocol'
+      );
+    });
+
+    it('rejects empty string', () => {
+      expect(() => validateServiceUrl('', 'Test')).toThrow('URL is required');
+    });
+
+    it('rejects malformed URL', () => {
+      expect(() => validateServiceUrl('not a url', 'Test')).toThrow('Invalid URL format');
+    });
+
+    it('includes service name in error message', () => {
+      expect(() => validateServiceUrl('', 'Tautulli')).toThrow('Tautulli: URL is required');
+    });
+
+    it('rejects javascript: protocol', () => {
+      expect(() => validateServiceUrl('javascript:alert(1)', 'Test')).toThrow(
+        'URL must use http or https protocol'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Addresses CodeQL code scanning alert #50 (`js/request-forgery` / SSRF).

The alert flagged `fetch-with-timeout.ts` line 26 because user-controlled URLs flowed into `fetchWithTimeout()` without scheme validation at four call sites.

## Changes

Added `validateServiceUrl()` (already used by Lidarr and slskd) to the four unprotected call sites:

| File | Location | URL source |
|------|----------|-----------|
| `services/tautulli.ts` | `callApi()` | `config.tautulliUrl` |
| `services/jellyfin.ts` | `callApi()` | `config.jellyfinUrl` |
| `services/notifications.ts` | `sendDiscord()` | `config.webhookUrl` |
| `services/notifications.ts` | `sendWebhook()` | `config.url` |

`validateServiceUrl()` rejects non-HTTP(S) schemes (`file://`, `ftp://`, `javascript:`, etc.), rejects malformed URLs, parses and reassembles the URL from its components, and returns a normalized string — which also resets CodeQL's taint-tracking chain.

Services that were already safe (Lidarr, slskd use `validateServiceUrl()`; Spotify/Bandcamp/update-checker use hardcoded URLs) are unchanged.

## Tests

Added `tests/lib/validate-service-url.test.ts` with 12 tests covering valid http/https URLs, protocol rejection, malformed input, and error message formatting. All 501 existing tests continue to pass.