### PR TITLE
fix(docker): hotfix v2.1.3 - fix Dockerfile.unified node_modules COPY path

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -114,7 +114,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
 
@@ -228,7 +228,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=tag,suffix=-slim
-            type=raw,value=slim,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=slim,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=raw,value=${{ github.event.inputs.tag }}-slim,enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=slim,enable=${{ github.event_name == 'workflow_dispatch' }}
 

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -78,10 +78,8 @@ COPY --from=builder-api /app/apps/api/dist /app/api/dist
 COPY --from=builder-api /app/apps/api/package*.json /app/api/
 COPY --from=builder-api /app/apps/api/prisma /app/api/prisma
 
-# Copy node_modules - both root hoisted deps AND api-specific deps
-# Order matters: api-specific deps should overlay root deps
+# Copy node_modules - npm workspaces hoists all deps to root
 COPY --from=builder-api /app/node_modules /app/api/node_modules
-COPY --from=builder-api /app/apps/api/node_modules /app/api/node_modules
 
 # Generate Prisma client in production
 WORKDIR /app/api


### PR DESCRIPTION
## Problem

The v2.1.2 Docker build failed with:
```
ERROR: failed to build: failed to solve: failed to compute cache key: "/app/apps/api/node_modules": not found
```

## Root Cause

`docker/Dockerfile.unified` had two COPY lines for node_modules:
```dockerfile
COPY --from=builder-api /app/node_modules /app/api/node_modules
COPY --from=builder-api /app/apps/api/node_modules /app/api/node_modules  # BROKEN
```

npm workspaces hoists all dependencies to `/app/node_modules`. The path `/app/apps/api/node_modules` does not exist in the builder stage, causing the build to fail.

The v2.1.2 PR fixed `apps/api/Dockerfile` but missed the same pattern in `docker/Dockerfile.unified`.

## Fix

1. Remove the broken COPY line from `docker/Dockerfile.unified`
2. Fix the `latest` tag condition in CI workflow — was still using `github.event_name == 'release'` after the trigger was changed to tag pushes, so `latest` was never being set

## Release

This will be released as v2.1.3 patch.