### PR TITLE
fix(network): fall back to IPv4 when host IPv6 egress is broken

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,9 @@ MYSQL_USER=mixarr
 # URLs (adjust for your domain/IP)
 BASE_URL=https://localhost:3443
 FRONTEND_URL=https://localhost:3443
+
+# Network preflight (optional)
+# Mixarr probes IPv6 egress at startup and falls back to IPv4 if it's broken.
+# Override the probe target, or set MIXARR_SKIP_NETWORK_PREFLIGHT=1 to disable.
+#IPV6_PROBE_HOST=musicbrainz.org
+#MIXARR_SKIP_NETWORK_PREFLIGHT=1

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Configure these in **Settings → AI**.
 | `BASE_URL` | **Required.** The full URL to access Mixarr. Used for OAuth redirects. | - |
 | `FRONTEND_URL` | Optional. If behind a reverse proxy, set this to the public URL. | - |
 | `TZ` | Timezone for scheduled tasks. | `UTC` |
+| `IPV6_PROBE_HOST` | Host probed at startup over IPv6 to detect broken v6 egress. If the probe fails, Mixarr prefers IPv4 for outbound fetches. | `musicbrainz.org` |
+| `MIXARR_SKIP_NETWORK_PREFLIGHT` | Set to `1` to skip the IPv6 egress probe entirely (e.g. on air-gapped hosts or when you want to force Node's default Happy Eyeballs behaviour). | - |
 
 ### Ports
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,13 @@ import { apiLimiter } from './middleware/rate-limiter.js';
 import { initializeScheduler } from './jobs/scheduler.js';
 import { redis } from './lib/redis.js';
 import slskdRouter, { cleanupQueueEvents } from './routes/slskd.js';
+import { applyNetworkPreflight } from './lib/network-preflight.js';
+
+// Probe outbound IPv6 connectivity before any worker establishes pools.
+// On hosts where v6 is advertised but egress is broken, this falls back to v4.
+if (process.env.NODE_ENV !== 'test') {
+  await applyNetworkPreflight();
+}
 
 // Import workers only in non-test environments to prevent test pollution
 if (process.env.NODE_ENV !== 'test') {

--- a/apps/api/src/lib/network-preflight.ts
+++ b/apps/api/src/lib/network-preflight.ts
@@ -17,15 +17,14 @@ import { createLogger } from './logger.js';
 
 const logger = createLogger('NetworkPreflight');
 
-const PROBE_HOST = process.env.IPV6_PROBE_HOST || 'musicbrainz.org';
 const PROBE_PORT = 443;
 const PROBE_TIMEOUT_MS = 1500;
 
-async function ipv6EgressWorks(): Promise<boolean> {
+async function ipv6EgressWorks(host: string): Promise<boolean> {
   let address: string;
   try {
     address = await new Promise<string>((resolve, reject) => {
-      dns.lookup(PROBE_HOST, { family: 6 }, (err, addr) => err ? reject(err) : resolve(addr));
+      dns.lookup(host, { family: 6 }, (err, addr) => err ? reject(err) : resolve(addr));
     });
   } catch {
     return false;
@@ -42,10 +41,11 @@ async function ipv6EgressWorks(): Promise<boolean> {
 export async function applyNetworkPreflight(): Promise<void> {
   if (process.env.MIXARR_SKIP_NETWORK_PREFLIGHT === '1') return;
 
-  const v6Works = await ipv6EgressWorks();
+  const host = process.env.IPV6_PROBE_HOST || 'musicbrainz.org';
+  const v6Works = await ipv6EgressWorks(host);
   if (v6Works) return;
 
-  logger.warn(`IPv6 egress to ${PROBE_HOST} unavailable — preferring IPv4 for outbound fetches`);
+  logger.warn(`IPv6 egress to ${host} unavailable — preferring IPv4 for outbound fetches`);
   dns.setDefaultResultOrder('ipv4first');
   net.setDefaultAutoSelectFamily(false);
 }

--- a/apps/api/src/lib/network-preflight.ts
+++ b/apps/api/src/lib/network-preflight.ts
@@ -1,0 +1,51 @@
+/**
+ * Network Preflight
+ *
+ * Some Docker/host networking setups (Hetzner LXC, OCI, misconfigured bridges)
+ * advertise IPv6 via DNS and a default route, but silently drop outbound v6
+ * packets. Node's `fetch` (undici) uses Happy Eyeballs and may attempt IPv6
+ * first, hanging until the request times out instead of falling back cleanly.
+ *
+ * On startup we probe a known dual-stack host over IPv6 with a short timeout.
+ * If that fails, we prefer IPv4 in DNS results and disable autoSelectFamily so
+ * outbound fetches go straight to v4. This is a no-op on healthy networks and
+ * on hosts without any IPv6 stack.
+ */
+import dns from 'node:dns';
+import net from 'node:net';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('NetworkPreflight');
+
+const PROBE_HOST = process.env.IPV6_PROBE_HOST || 'musicbrainz.org';
+const PROBE_PORT = 443;
+const PROBE_TIMEOUT_MS = 1500;
+
+async function ipv6EgressWorks(): Promise<boolean> {
+  let address: string;
+  try {
+    address = await new Promise<string>((resolve, reject) => {
+      dns.lookup(PROBE_HOST, { family: 6 }, (err, addr) => err ? reject(err) : resolve(addr));
+    });
+  } catch {
+    return false;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const sock = net.connect({ host: address, port: PROBE_PORT, family: 6 });
+    const timer = setTimeout(() => { sock.destroy(); resolve(false); }, PROBE_TIMEOUT_MS);
+    sock.once('connect', () => { clearTimeout(timer); sock.destroy(); resolve(true); });
+    sock.once('error',   () => { clearTimeout(timer); resolve(false); });
+  });
+}
+
+export async function applyNetworkPreflight(): Promise<void> {
+  if (process.env.MIXARR_SKIP_NETWORK_PREFLIGHT === '1') return;
+
+  const v6Works = await ipv6EgressWorks();
+  if (v6Works) return;
+
+  logger.warn(`IPv6 egress to ${PROBE_HOST} unavailable — preferring IPv4 for outbound fetches`);
+  dns.setDefaultResultOrder('ipv4first');
+  net.setDefaultAutoSelectFamily(false);
+}

--- a/apps/api/tests/unit/network-preflight.test.ts
+++ b/apps/api/tests/unit/network-preflight.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import dns from 'node:dns';
+import net from 'node:net';
+import { applyNetworkPreflight } from '../../src/lib/network-preflight.js';
+
+describe('applyNetworkPreflight', () => {
+  let originalResultOrder: 'ipv4first' | 'ipv6first' | 'verbatim';
+  let originalAutoSelectFamily: boolean;
+  let originalSkip: string | undefined;
+  let originalProbeHost: string | undefined;
+
+  beforeEach(() => {
+    originalResultOrder = dns.getDefaultResultOrder();
+    originalAutoSelectFamily = net.getDefaultAutoSelectFamily();
+    originalSkip = process.env.MIXARR_SKIP_NETWORK_PREFLIGHT;
+    originalProbeHost = process.env.IPV6_PROBE_HOST;
+  });
+
+  afterEach(() => {
+    dns.setDefaultResultOrder(originalResultOrder);
+    net.setDefaultAutoSelectFamily(originalAutoSelectFamily);
+    if (originalSkip === undefined) delete process.env.MIXARR_SKIP_NETWORK_PREFLIGHT;
+    else process.env.MIXARR_SKIP_NETWORK_PREFLIGHT = originalSkip;
+    if (originalProbeHost === undefined) delete process.env.IPV6_PROBE_HOST;
+    else process.env.IPV6_PROBE_HOST = originalProbeHost;
+  });
+
+  it('is a no-op when MIXARR_SKIP_NETWORK_PREFLIGHT=1', async () => {
+    process.env.MIXARR_SKIP_NETWORK_PREFLIGHT = '1';
+    // Point at a host that would otherwise fail and trigger fallback,
+    // to prove the skip flag short-circuits before the probe runs.
+    process.env.IPV6_PROBE_HOST = 'nonexistent.invalid';
+
+    await applyNetworkPreflight();
+
+    expect(dns.getDefaultResultOrder()).toBe(originalResultOrder);
+    expect(net.getDefaultAutoSelectFamily()).toBe(originalAutoSelectFamily);
+  });
+
+  it('falls back to IPv4 when the probe host is unresolvable', async () => {
+    // RFC 6761 guarantees .invalid never resolves — exercises the failure
+    // path without mocking DNS or network.
+    process.env.IPV6_PROBE_HOST = 'nonexistent.invalid';
+    delete process.env.MIXARR_SKIP_NETWORK_PREFLIGHT;
+
+    await applyNetworkPreflight();
+
+    expect(dns.getDefaultResultOrder()).toBe('ipv4first');
+    expect(net.getDefaultAutoSelectFamily()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/aquantumofdonuts/mixarr/issues/35

## Summary
- Adds a startup TCP probe over IPv6 to a known dual-stack host (default `musicbrainz.org`). If it fails, Mixarr sets `dns.setDefaultResultOrder('ipv4first')` and disables `net.setDefaultAutoSelectFamily` so subsequent `fetch` calls go straight to v4 instead of hanging on Happy Eyeballs.
- Runs before workers/clients are imported, so BullMQ, Spotify, MusicBrainz, Last.fm, etc. inherit the v4 preference on broken-v6 hosts (Hetzner LXC, OCI, misconfigured bridges).
- Documents the two operator knobs (`IPV6_PROBE_HOST`, `MIXARR_SKIP_NETWORK_PREFLIGHT`) in `README.md` and `.env.example`.

## Why
On hosts that advertise IPv6 via DNS/default route but silently drop outbound v6 packets, undici tries v6 first and times out, surfacing as `TypeError: fetch failed (ETIMEDOUT)` against MusicBrainz/Last.fm/etc. The preflight is a no-op on healthy networks and on hosts without a v6 stack.

## Test plan
- [ ] Boot on a healthy dual-stack host — log line absent, v6 still used.
- [ ] Boot on a host with broken v6 egress — warn log fires, outbound fetches succeed over v4.
- [ ] Boot with `MIXARR_SKIP_NETWORK_PREFLIGHT=1` — probe is skipped, default Happy Eyeballs behaviour.
- [ ] Boot with `IPV6_PROBE_HOST=example.com` — probe targets the override.