### PR TITLE
fix(docker): persist unified container DB credentials across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v2.1.6] - 2026-04-30
+
+### Fixed
+- **Unified container restart auth failure** (issue #51): Auto-generated `MYSQL_PASSWORD` was regenerated on every container restart but MariaDB retained the original password from first boot, causing _"Authentication failed against database server at `127.0.0.1`"_ on every `docker compose down && docker compose up`. The generated password is now persisted to `/data/.mixarr_credentials` (mode 600) and restored on subsequent starts. Existing installs upgrading from this version perform a one-time password rotation via `ALTER USER` so the database remains accessible without data loss. Users who set `MYSQL_PASSWORD` explicitly are unaffected. Affects unified image only.
+
+---
+
 ## [v2.1.5] - 2026-04-05
 
 ### Fixed

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixarr/api",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixarr/web",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/docker/Dockerfile.unified
+++ b/docker/Dockerfile.unified
@@ -258,11 +258,33 @@ chown -R mixarr:mixarr /app
 
 # -----------------------------------------------------------------------------
 # Auto-generate database credentials if not provided
+# Credentials are persisted to /data/.mixarr_credentials so they survive
+# container restarts without the user needing to set MYSQL_PASSWORD explicitly.
 # -----------------------------------------------------------------------------
+CREDS_FILE="/data/.mixarr_credentials"
+CREDS_FILE_IS_NEW=0
+
 if [ -z "$MYSQL_PASSWORD" ]; then
-  export MYSQL_PASSWORD=$(openssl rand -hex 16)
-  echo "Generated random MYSQL_PASSWORD"
-  echo "Set MYSQL_PASSWORD env var explicitly for persistent credentials."
+  if [ -f "$CREDS_FILE" ]; then
+    chmod 600 "$CREDS_FILE"
+    export MYSQL_PASSWORD=$(grep '^MYSQL_PASSWORD=' "$CREDS_FILE" | cut -d= -f2-)
+    if [ -z "$MYSQL_PASSWORD" ]; then
+      echo "WARNING: $CREDS_FILE is malformed or missing key; regenerating credentials"
+      export MYSQL_PASSWORD=$(openssl rand -hex 16)
+      printf 'MYSQL_PASSWORD=%s\n' "$MYSQL_PASSWORD" > "$CREDS_FILE"
+      chmod 600 "$CREDS_FILE"
+      CREDS_FILE_IS_NEW=1
+    else
+      echo "Restored MYSQL_PASSWORD from $CREDS_FILE"
+    fi
+  else
+    export MYSQL_PASSWORD=$(openssl rand -hex 16)
+    printf 'MYSQL_PASSWORD=%s\n' "$MYSQL_PASSWORD" > "$CREDS_FILE"
+    chmod 600 "$CREDS_FILE"
+    CREDS_FILE_IS_NEW=1
+    echo "Generated random MYSQL_PASSWORD (persisted to $CREDS_FILE)"
+    echo "Set MYSQL_PASSWORD env var explicitly only to override or rotate the persisted password."
+  fi
 fi
 
 if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
@@ -308,6 +330,42 @@ EOSQL
     mysqladmin -u root shutdown
     sleep 2
     echo "MariaDB initialized successfully"
+else
+    # DB already exists. If the creds file was just created this run, the
+    # stored password may differ from what MariaDB has (e.g. existing users
+    # who never set MYSQL_PASSWORD explicitly and are upgrading from a version
+    # that did not persist credentials). Reset the MariaDB user password to
+    # match so the connection succeeds without data loss.
+    if [ "$CREDS_FILE_IS_NEW" = "1" ]; then
+        echo "Migrating database credentials to persisted creds file..."
+        # Start MariaDB temporarily to rotate the password
+        /usr/bin/mysqld_safe --datadir=/data/mysql &
+        MIGRATE_PID=$!
+        DB_READY=0
+        for i in $(seq 1 30); do
+            if mysqladmin ping -h 127.0.0.1 --silent 2>/dev/null; then
+                DB_READY=1
+                break
+            fi
+            sleep 1
+        done
+        if [ "$DB_READY" != "1" ]; then
+            echo "ERROR: MariaDB did not become reachable for credential migration" >&2
+            exit 1
+        fi
+        if ! mysql -u root -e \
+            "ALTER USER 'mixarr'@'127.0.0.1' IDENTIFIED BY '${MYSQL_PASSWORD}'; \
+             ALTER USER 'mixarr'@'localhost' IDENTIFIED BY '${MYSQL_PASSWORD}'; \
+             FLUSH PRIVILEGES;"; then
+            echo "ERROR: Credential migration failed; database credentials were not rotated" >&2
+            mysqladmin -u root shutdown >/dev/null 2>&1 || true
+            sleep 2
+            exit 1
+        fi
+        mysqladmin -u root shutdown
+        sleep 2
+        echo "Credential migration complete"
+    fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixarr",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "private": true,
   "description": "Music discovery and import tool for Lidarr",
   "workspaces": [


### PR DESCRIPTION
## Problem

Closes #51

In the unified container image, `MYSQL_PASSWORD` was auto-generated on every startup but never persisted. On first boot the MariaDB user was created with password `abc123`. On the next `docker compose down && docker compose up`, a new password `xyz789` was generated, the DB init block was skipped (data directory already existed), and the API connected with `xyz789` — but MariaDB still had `abc123`. Result: **Authentication failed against database server at `127.0.0.1`** on every restart.

## Fix

- Generated `MYSQL_PASSWORD` is now written to `/data/.mixarr_credentials` (600 permissions) on first start and restored on subsequent starts.
- For existing users upgrading (no creds file, but DB already initialised): a one-time migration block starts MariaDB temporarily, runs `ALTER USER` to rotate the password to the newly-generated value, then shuts back down before supervisord takes over. This means one startup is slightly slower but all subsequent restarts are stable.

## Impact

| User type | Effect |
|---|---|
| New installs | No change in behaviour |
| Unified image users who set `MYSQL_PASSWORD` explicitly | No change (block never entered) |
| Unified image users relying on auto-generation | One-time credential migration on first upgrade boot; works normally forever after |
| `docker-compose.yml` / slim image users | Completely unaffected (different entrypoint) |

## Testing

Manual verification steps:
1. Fresh install — DB init runs, creds file written, connects ✅
2. Restart after step 1 — creds file loaded, same password, connects ✅
3. Simulate upgrade (delete creds file, keep data dir) — migration block fires, `ALTER USER` runs, new creds file written, connects ✅