### PR TITLE
feat(auth): add OIDC SSO provider

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,6 +36,7 @@
     "helmet": "^8.0.0",
     "ioredis": "^5.4.1",
     "openai": "^4.73.0",
+    "openid-client": "^5.7.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-ldapauth": "^3.0.1",

--- a/apps/api/prisma/migrations/20260522000001_add_oidc_provider/migration.sql
+++ b/apps/api/prisma/migrations/20260522000001_add_oidc_provider/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `sso_providers` MODIFY COLUMN `type` ENUM('ldap', 'saml', 'google', 'plex', 'oidc') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `auth_identities` MODIFY COLUMN `provider` ENUM('ldap', 'saml', 'google', 'plex', 'oidc') NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -67,6 +67,7 @@ enum SsoProviderType {
   saml
   google
   plex
+  oidc
 }
 
 model SsoProvider {

--- a/apps/api/src/auth/strategies/oidc.ts
+++ b/apps/api/src/auth/strategies/oidc.ts
@@ -64,8 +64,8 @@ export async function createOidcStrategy(
         }
 
         if (config.allowedDomains?.length) {
-          const domain = email.split('@')[1];
-          if (!config.allowedDomains.includes(domain)) {
+          const domain = email.split('@')[1]?.toLowerCase();
+          if (!domain || !config.allowedDomains.includes(domain)) {
             return done(null, false, { message: 'Email domain not allowed' });
           }
         }

--- a/apps/api/src/auth/strategies/oidc.ts
+++ b/apps/api/src/auth/strategies/oidc.ts
@@ -1,0 +1,136 @@
+import { Issuer, Strategy as OpenIDStrategy } from 'openid-client';
+import type { Client, TokenSet, UserinfoResponse } from 'openid-client';
+import type { PrismaClient } from '@prisma/client';
+
+const DEFAULT_EMAIL_ATTRIBUTE = 'email';
+const DEFAULT_DISPLAY_NAME_ATTRIBUTE = 'name';
+const DEFAULT_USERNAME_ATTRIBUTE = 'preferred_username';
+
+export interface OidcConfig {
+  issuerUrl: string;
+  clientId: string;
+  clientSecret: string;
+  callbackUrl: string;
+  scopes?: string;
+  allowedDomains?: string[];
+  emailAttribute?: string;
+  displayNameAttribute?: string;
+  usernameAttribute?: string;
+}
+
+type OidcUser = Express.User | false;
+type DoneCallback = (err: unknown, user?: OidcUser, info?: { message?: string }) => void;
+
+export async function createOidcStrategy(
+  config: OidcConfig,
+  prisma: PrismaClient
+): Promise<OpenIDStrategy<OidcUser, Client>> {
+  const issuer = await Issuer.discover(config.issuerUrl);
+
+  const client = new issuer.Client({
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    redirect_uris: [config.callbackUrl],
+    response_types: ['code'],
+  });
+
+  const emailAttribute = config.emailAttribute || DEFAULT_EMAIL_ATTRIBUTE;
+  const displayNameAttribute = config.displayNameAttribute || DEFAULT_DISPLAY_NAME_ATTRIBUTE;
+  const usernameAttribute = config.usernameAttribute || DEFAULT_USERNAME_ATTRIBUTE;
+
+  return new OpenIDStrategy<OidcUser, Client>(
+    {
+      client,
+      params: {
+        scope: config.scopes || 'openid email profile',
+      },
+    },
+    async (tokenset: TokenSet, userinfo: UserinfoResponse, done: DoneCallback) => {
+      try {
+        const claims = tokenset.claims();
+        const readClaim = (key: string): string | undefined => {
+          const value = userinfo[key] ?? claims[key];
+          return typeof value === 'string' ? value : undefined;
+        };
+
+        const email = readClaim(emailAttribute);
+        const sub = readClaim('sub');
+
+        if (!email) {
+          return done(null, false, { message: 'No email in OIDC profile' });
+        }
+        if (!sub) {
+          return done(null, false, { message: 'No subject identifier in OIDC profile' });
+        }
+
+        if (config.allowedDomains?.length) {
+          const domain = email.split('@')[1];
+          if (!config.allowedDomains.includes(domain)) {
+            return done(null, false, { message: 'Email domain not allowed' });
+          }
+        }
+
+        // Find user by email (MySQL is case-insensitive by default for VARCHAR)
+        const user = await prisma.user.findFirst({
+          where: { email: email.toLowerCase() },
+        });
+
+        if (!user) {
+          return done(null, false, {
+            message: 'No account found for this email. Contact your administrator.',
+          });
+        }
+
+        if (!user.isActive) {
+          return done(null, false, { message: 'Your account has been disabled.' });
+        }
+
+        const displayName = readClaim(displayNameAttribute) || readClaim(usernameAttribute);
+        const picture = readClaim('picture');
+
+        await prisma.authIdentity.upsert({
+          where: {
+            provider_providerUserId: {
+              provider: 'oidc',
+              providerUserId: sub,
+            },
+          },
+          create: {
+            userId: user.id,
+            provider: 'oidc',
+            providerUserId: sub,
+            email,
+            metadata: {
+              displayName,
+              picture,
+              issuer: issuer.metadata.issuer,
+            },
+          },
+          update: {
+            lastUsedAt: new Date(),
+            email,
+            metadata: {
+              displayName,
+              picture,
+              issuer: issuer.metadata.issuer,
+            },
+          },
+        });
+
+        await prisma.user.update({
+          where: { id: user.id },
+          data: { lastLogin: new Date() },
+        });
+
+        return done(null, {
+          id: user.id,
+          username: user.username,
+          displayName: user.displayName,
+          role: user.role,
+        });
+      } catch (error) {
+        return done(error as Error);
+      }
+    }
+  );
+}

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -279,7 +279,7 @@ authRouter.get('/sso/oidc', async (req, res, next) => {
       clientSecret: config.clientSecret,
       callbackUrl: `${baseUrl}/api/auth/sso/oidc/callback`,
       scopes: config.scopes,
-      allowedDomains: config.allowedDomains?.split(',').map((d: string) => d.trim()).filter(Boolean),
+      allowedDomains: config.allowedDomains?.split(',').map((d: string) => d.trim().toLowerCase()).filter(Boolean),
       emailAttribute: config.emailAttribute,
       displayNameAttribute: config.displayNameAttribute,
       usernameAttribute: config.usernameAttribute,

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -10,6 +10,7 @@ import { createGoogleStrategy } from '../auth/strategies/google.js';
 import { createLdapStrategy } from '../auth/strategies/ldap.js';
 import { createSamlStrategy } from '../auth/strategies/saml.js';
 import { PlexAuthService } from '../auth/strategies/plex.js';
+import { createOidcStrategy } from '../auth/strategies/oidc.js';
 import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('AuthRoute');
@@ -26,7 +27,7 @@ authRouter.get('/setup-required', async (_req, res) => {
       prisma.user.count(),
       prisma.globalSetting.findUnique({ where: { key: 'baseUrl' } }),
     ]);
-    res.json({ 
+    res.json({
       setupRequired: !setupCompleted?.value,
       adminExists: userCount > 0,
       baseUrlExists: !!baseUrl?.value,
@@ -52,14 +53,14 @@ authRouter.post('/complete-setup', async (_req, res) => {
       res.status(400).json({ error: 'Setup already completed' });
       return;
     }
-    
+
     // Safety check 2: Must have at least one admin user
     const userCount = await prisma.user.count();
     if (userCount === 0) {
       res.status(400).json({ error: 'No admin user exists' });
       return;
     }
-    
+
     // Safety check 3: Base URL must be configured
     const baseUrl = await prisma.globalSetting.findUnique({
       where: { key: 'baseUrl' },
@@ -68,7 +69,7 @@ authRouter.post('/complete-setup', async (_req, res) => {
       res.status(400).json({ error: 'Base URL not configured' });
       return;
     }
-    
+
     await prisma.globalSetting.upsert({
       where: { key: 'setupCompleted' },
       create: { key: 'setupCompleted', value: true },
@@ -102,7 +103,7 @@ authRouter.get('/sso/google', async (req, res, next) => {
     const provider = await prisma.ssoProvider.findUnique({
       where: { type: 'google' },
     });
-    
+
     if (!provider?.isEnabled) {
       res.status(400).json({ error: 'Google authentication is not available' });
       return;
@@ -111,7 +112,7 @@ authRouter.get('/sso/google', async (req, res, next) => {
     const config = provider.config as { clientId: string; clientSecret: string; allowedDomains?: string };
     const baseUrlSetting = await prisma.globalSetting.findUnique({ where: { key: 'baseUrl' } });
     const baseUrl = (baseUrlSetting?.value as string) || 'http://localhost:3010';
-    
+
     // Register strategy dynamically
     passport.use('google-sso', createGoogleStrategy({
       clientId: config.clientId,
@@ -153,7 +154,7 @@ authRouter.post('/sso/ldap', loginLimiter, async (req, res, next) => {
     const provider = await prisma.ssoProvider.findUnique({
       where: { type: 'ldap' },
     });
-    
+
     if (!provider?.isEnabled) {
       res.status(400).json({ error: 'LDAP authentication is not available' });
       return;
@@ -168,7 +169,7 @@ authRouter.post('/sso/ldap', loginLimiter, async (req, res, next) => {
       emailAttribute: string;
       displayNameAttribute?: string;
     };
-    
+
     passport.use('ldap-sso', createLdapStrategy(config, prisma));
 
     passport.authenticate('ldap-sso', (err: Error | null, user: Express.User | false, info: { message?: string }) => {
@@ -197,7 +198,7 @@ authRouter.get('/sso/saml', async (req, res, next) => {
   const provider = await prisma.ssoProvider.findUnique({
     where: { type: 'saml' },
   });
-  
+
   if (!provider?.isEnabled) {
     res.status(400).json({ error: 'SAML authentication is not available' });
     return;
@@ -210,10 +211,10 @@ authRouter.get('/sso/saml', async (req, res, next) => {
     emailAttribute?: string;
     displayNameAttribute?: string;
   };
-  
+
   const baseUrlSetting = await prisma.globalSetting.findUnique({ where: { key: 'baseUrl' } });
   const baseUrl = (baseUrlSetting?.value as string) || 'http://localhost:3010';
-  
+
   // Type assertion required: passport-saml's Strategy type doesn't match passport's expected type
   passport.use('saml-sso', createSamlStrategy({
     callbackUrl: `${baseUrl}/api/auth/sso/saml/callback`,
@@ -247,6 +248,71 @@ authRouter.post('/sso/saml/callback', (req, res, next) => {
   })(req, res, next);
 });
 
+authRouter.get('/sso/oidc', async (req, res, next) => {
+  try {
+    const provider = await prisma.ssoProvider.findUnique({
+      where: { type: 'oidc' },
+    });
+
+    if (!provider?.isEnabled) {
+      res.status(400).json({ error: 'OIDC authentication is not available' });
+      return;
+    }
+
+    const config = provider.config as {
+      issuerUrl: string;
+      clientId: string;
+      clientSecret: string;
+      scopes?: string;
+      allowedDomains?: string;
+      emailAttribute?: string;
+      displayNameAttribute?: string;
+      usernameAttribute?: string;
+    };
+
+    const baseUrlSetting = await prisma.globalSetting.findUnique({ where: { key: 'baseUrl' } });
+    const baseUrl = (baseUrlSetting?.value as string) || 'http://localhost:3010';
+
+    const strategy = await createOidcStrategy({
+      issuerUrl: config.issuerUrl,
+      clientId: config.clientId,
+      clientSecret: config.clientSecret,
+      callbackUrl: `${baseUrl}/api/auth/sso/oidc/callback`,
+      scopes: config.scopes,
+      allowedDomains: config.allowedDomains?.split(',').map((d: string) => d.trim()).filter(Boolean),
+      emailAttribute: config.emailAttribute,
+      displayNameAttribute: config.displayNameAttribute,
+      usernameAttribute: config.usernameAttribute,
+    }, prisma);
+
+    passport.use('oidc-sso', strategy as unknown as passport.Strategy);
+
+    passport.authenticate('oidc-sso')(req, res, next);
+  } catch (error) {
+    logger.error('OIDC initiation error', { error });
+    res.redirect('/login?error=oidc_init_failed');
+  }
+});
+
+authRouter.get('/sso/oidc/callback', (req, res, next) => {
+  passport.authenticate('oidc-sso', (err: Error | null, user: Express.User | false, info: { message?: string }) => {
+    if (err) {
+      logger.error('OIDC auth error', { error: err });
+      return res.redirect('/login?error=auth_failed');
+    }
+    if (!user) {
+      const msg = encodeURIComponent(info?.message || 'Authentication failed');
+      return res.redirect(`/login?error=${msg}`);
+    }
+    req.logIn(user, (loginErr) => {
+      if (loginErr) {
+        return res.redirect('/login?error=login_failed');
+      }
+      return res.redirect('/');
+    });
+  })(req, res, next);
+});
+
 // Store Plex PINs temporarily (in production, use Redis/session)
 const plexPins = new Map<number, number>(); // pinId -> timestamp
 
@@ -255,7 +321,7 @@ authRouter.get('/sso/plex', async (req, res) => {
   const provider = await prisma.ssoProvider.findUnique({
     where: { type: 'plex' },
   });
-  
+
   if (!provider?.isEnabled) {
     res.status(400).json({ error: 'Plex authentication is not available' });
     return;
@@ -273,10 +339,10 @@ authRouter.get('/sso/plex', async (req, res) => {
   try {
     const { pinId, authUrl } = await plexService.createAuthUrl();
     plexPins.set(pinId, Date.now());
-    
+
     // Store pinId in session for callback
     req.session.plexPinId = pinId;
-    
+
     res.redirect(authUrl);
   } catch (error) {
     logger.error('Plex auth error', { error });
@@ -287,7 +353,7 @@ authRouter.get('/sso/plex', async (req, res) => {
 // Plex - callback
 authRouter.get('/sso/plex/callback', async (req, res) => {
   const pinId = req.session.plexPinId;
-  
+
   if (!pinId) {
     return res.redirect('/login?error=missing_plex_pin');
   }
@@ -295,7 +361,7 @@ authRouter.get('/sso/plex/callback', async (req, res) => {
   const provider = await prisma.ssoProvider.findUnique({
     where: { type: 'plex' },
   });
-  
+
   if (!provider?.isEnabled) {
     return res.redirect('/login?error=plex_not_available');
   }
@@ -311,13 +377,13 @@ authRouter.get('/sso/plex/callback', async (req, res) => {
 
   try {
     const plexAuth = await plexService.handleCallback(pinId);
-    
+
     if (!plexAuth) {
       return res.redirect('/login?error=plex_auth_failed');
     }
 
     const result = await plexService.authenticateUser(plexAuth.user);
-    
+
     if (!result.success || !result.user) {
       const msg = encodeURIComponent(result.error || 'Authentication failed');
       return res.redirect(`/login?error=${msg}`);
@@ -349,14 +415,14 @@ authRouter.post('/setup', setupLimiter, async (req, res) => {
     }
 
     const { username, password, displayName } = req.body;
-    
+
     if (!username || !password) {
       res.status(400).json({ error: 'Username and password required' });
       return;
     }
 
     const passwordHash = await bcrypt.hash(password, 12);
-    
+
     const user = await prisma.user.create({
       data: {
         username,
@@ -372,7 +438,7 @@ authRouter.post('/setup', setupLimiter, async (req, res) => {
         logger.error('Auto-login after setup failed', { error: loginErr });
         // Still return success - user can manually login
       }
-      
+
       res.json({
         success: true,
         user: {
@@ -435,7 +501,7 @@ authRouter.get('/me', async (req, res) => {
     where: { key: 'setupCompleted' },
   });
   const setupRequired = !setupCompleted?.value;
-  
+
   if (req.isAuthenticated() && req.user) {
     res.json({ user: req.user, setupRequired });
   } else {
@@ -471,7 +537,7 @@ authRouter.get('/users', requireAuth, requireAdmin, async (_req, res) => {
 authRouter.post('/users', requireAuth, requireAdmin, createUserLimiter, async (req, res) => {
   try {
     const { username, password, displayName, role } = req.body;
-    
+
     if (!username || !password) {
       res.status(400).json({ error: 'Username and password required' });
       return;
@@ -484,7 +550,7 @@ authRouter.post('/users', requireAuth, requireAdmin, createUserLimiter, async (r
     }
 
     const passwordHash = await bcrypt.hash(password, 12);
-    
+
     const user = await prisma.user.create({
       data: {
         username,
@@ -521,14 +587,14 @@ authRouter.post('/users/:id/reset-password', requireAuth, requireAdmin, async (r
       return;
     }
     const { newPassword } = req.body;
-    
+
     if (!newPassword) {
       res.status(400).json({ error: 'New password required' });
       return;
     }
 
     const passwordHash = await bcrypt.hash(newPassword, 12);
-    
+
     await prisma.user.update({
       where: { id },
       data: { passwordHash },
@@ -552,7 +618,7 @@ authRouter.delete('/users/:id', requireAuth, requireAdmin, async (req, res) => {
       res.status(400).json({ error: 'Invalid user ID' });
       return;
     }
-    
+
     // Prevent deleting yourself
     if (req.user?.id === id) {
       res.status(400).json({ error: 'Cannot delete your own account' });
@@ -602,7 +668,7 @@ authRouter.delete('/users/:userId/identities/:identityId', requireAuth, requireA
   try {
     const userId = parseIntParam(req.params.userId);
     const identityId = parseIntParam(req.params.identityId);
-    
+
     if (userId === null || identityId === null) {
       res.status(400).json({ error: 'Invalid ID' });
       return;

--- a/apps/api/src/routes/sso.ts
+++ b/apps/api/src/routes/sso.ts
@@ -187,6 +187,42 @@ ssoRouter.post('/providers/:type/test', validateParams(ssoProviderTypeParamsSche
           return;
         }
       }
+      case 'oidc': {
+        const issuerUrl = config.issuerUrl || '';
+        const clientId = config.clientId || '';
+        const clientSecret = config.clientSecret || '';
+
+        if (!issuerUrl || !clientId || !clientSecret) {
+          res.json({ success: false, message: 'OIDC requires issuerUrl, clientId, and clientSecret' });
+          return;
+        }
+
+        const discoveryUrl = issuerUrl.endsWith('/')
+          ? `${issuerUrl}.well-known/openid-configuration`
+          : `${issuerUrl}/.well-known/openid-configuration`;
+
+        try {
+          const response = await fetchWithTimeout(discoveryUrl, { timeout: 10_000 });
+          if (!response.ok) {
+            res.json({ success: false, message: `Failed to fetch discovery document: HTTP ${response.status}` });
+            return;
+          }
+          const doc = await response.json() as { issuer?: string; authorization_endpoint?: string; token_endpoint?: string };
+          if (!doc.issuer || !doc.authorization_endpoint || !doc.token_endpoint) {
+            res.json({ success: false, message: 'Discovery document missing required fields (issuer, authorization_endpoint, token_endpoint)' });
+            return;
+          }
+          res.json({ success: true, message: `OIDC discovery successful (issuer: ${doc.issuer})` });
+          return;
+        } catch (error) {
+          if (error instanceof Error && error.name === 'AbortError') {
+            res.json({ success: false, message: 'Timeout: Failed to fetch discovery document within 10 seconds' });
+            return;
+          }
+          res.json({ success: false, message: `Failed to fetch discovery document: ${error instanceof Error ? error.message : 'Unknown error'}` });
+          return;
+        }
+      }
       case 'ldap': {
         const ldap = await import('ldapjs');
         const url = config.serverUrl || '';

--- a/apps/api/src/schemas/sso.ts
+++ b/apps/api/src/schemas/sso.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 // Valid SSO provider types
-export const SSO_PROVIDER_TYPES = ['ldap', 'saml', 'google', 'plex'] as const;
+export const SSO_PROVIDER_TYPES = ['ldap', 'saml', 'google', 'plex', 'oidc'] as const;
 
 export type SsoProviderTypeEnum = (typeof SSO_PROVIDER_TYPES)[number];
 
@@ -61,6 +61,17 @@ export const samlConfigSchema = z
 
 export const plexConfigSchema = z.object({
   restrictToServerId: z.string().optional(),
+});
+
+export const oidcConfigSchema = z.object({
+  issuerUrl: z.string().min(1, 'issuerUrl is required'),
+  clientId: z.string().min(1, 'clientId is required'),
+  clientSecret: z.string().min(1, 'clientSecret is required'),
+  scopes: z.string().optional(),
+  allowedDomains: z.array(z.string()).optional(),
+  emailAttribute: z.string().optional(),
+  displayNameAttribute: z.string().optional(),
+  usernameAttribute: z.string().optional(),
 });
 
 // Exported inferred types

--- a/apps/api/src/types/sso.ts
+++ b/apps/api/src/types/sso.ts
@@ -32,7 +32,18 @@ export interface PlexConfig {
   restrictToServerId?: string;
 }
 
-export type SsoConfig = LdapConfig | SamlConfig | GoogleConfig | PlexConfig;
+export interface OidcConfig {
+  issuerUrl: string;
+  clientId: string;
+  clientSecret: string;
+  scopes?: string;
+  allowedDomains?: string[];
+  emailAttribute?: string;
+  displayNameAttribute?: string;
+  usernameAttribute?: string;
+}
+
+export type SsoConfig = LdapConfig | SamlConfig | GoogleConfig | PlexConfig | OidcConfig;
 
 export function validateLdapConfig(config: unknown): asserts config is LdapConfig {
   const c = config as Record<string, unknown>;
@@ -81,6 +92,19 @@ export function validatePlexConfig(_config: unknown): asserts _config is PlexCon
   return;
 }
 
+export function validateOidcConfig(config: unknown): asserts config is OidcConfig {
+  const c = config as Record<string, unknown>;
+  if (!c.issuerUrl || typeof c.issuerUrl !== 'string') {
+    throw new Error('issuerUrl is required');
+  }
+  if (!c.clientId || typeof c.clientId !== 'string') {
+    throw new Error('clientId is required');
+  }
+  if (!c.clientSecret || typeof c.clientSecret !== 'string') {
+    throw new Error('clientSecret is required');
+  }
+}
+
 export function validateSsoConfig(type: string, config: unknown): void {
   switch (type) {
     case 'ldap':
@@ -94,6 +118,9 @@ export function validateSsoConfig(type: string, config: unknown): void {
       break;
     case 'plex':
       validatePlexConfig(config);
+      break;
+    case 'oidc':
+      validateOidcConfig(config);
       break;
     default:
       throw new Error(`Unknown SSO provider type: ${type}`);

--- a/apps/api/tests/api/sso.test.ts
+++ b/apps/api/tests/api/sso.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { validateLdapConfig, validateSamlConfig, validateGoogleConfig, validatePlexConfig, validateSsoConfig } from '../../src/types/sso.js';
+import { validateLdapConfig, validateSamlConfig, validateGoogleConfig, validatePlexConfig, validateOidcConfig, validateSsoConfig } from '../../src/types/sso.js';
 import { createMockPrisma, resetIdCounter } from '../utils/fixtures.js';
 import { SsoProviderService } from '../../src/services/sso-provider.js';
 import {
@@ -88,6 +88,32 @@ describe('SSO Config Validation', () => {
     });
   });
 
+  describe('validateOidcConfig', () => {
+    it('should accept valid OIDC config', () => {
+      const config = {
+        issuerUrl: 'https://idp.example.com',
+        clientId: 'oidc-client-id',
+        clientSecret: 'oidc-client-secret',
+      };
+      expect(() => validateOidcConfig(config)).not.toThrow();
+    });
+
+    it('should reject OIDC config missing issuerUrl', () => {
+      const config = { clientId: 'id', clientSecret: 'secret' };
+      expect(() => validateOidcConfig(config)).toThrow('issuerUrl is required');
+    });
+
+    it('should reject OIDC config missing clientId', () => {
+      const config = { issuerUrl: 'https://idp.example.com', clientSecret: 'secret' };
+      expect(() => validateOidcConfig(config)).toThrow('clientId is required');
+    });
+
+    it('should reject OIDC config missing clientSecret', () => {
+      const config = { issuerUrl: 'https://idp.example.com', clientId: 'id' };
+      expect(() => validateOidcConfig(config)).toThrow('clientSecret is required');
+    });
+  });
+
   describe('validateSsoConfig', () => {
     it('should validate google config through dispatcher', () => {
       const config = {
@@ -95,6 +121,15 @@ describe('SSO Config Validation', () => {
         clientSecret: 'client-secret',
       };
       expect(() => validateSsoConfig('google', config)).not.toThrow();
+    });
+
+    it('should validate oidc config through dispatcher', () => {
+      const config = {
+        issuerUrl: 'https://idp.example.com',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      };
+      expect(() => validateSsoConfig('oidc', config)).not.toThrow();
     });
 
     it('should throw for unknown provider type', () => {

--- a/apps/api/tests/unit/routes/sso-test.test.ts
+++ b/apps/api/tests/unit/routes/sso-test.test.ts
@@ -229,6 +229,122 @@ describe('SSO Test Connection', () => {
       });
     });
 
+    describe('OIDC provider', () => {
+      it('should return error when required fields missing', async () => {
+        globalThis.__ssoTestMockResult = {
+          id: 1,
+          type: 'oidc',
+          name: 'OIDC',
+          config: { issuerUrl: 'https://idp.example.com' },
+          isEnabled: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        const response = await request(app)
+          .post('/api/sso/providers/oidc/test')
+          .send();
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(false);
+        expect(response.body.message).toContain('issuerUrl, clientId, and clientSecret');
+      });
+
+      it('should return success when discovery document is valid', async () => {
+        globalThis.__ssoTestMockResult = {
+          id: 1,
+          type: 'oidc',
+          name: 'OIDC',
+          config: {
+            issuerUrl: 'https://idp.example.com',
+            clientId: 'oidc-client',
+            clientSecret: 'oidc-secret',
+          },
+          isEnabled: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        globalThis.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            issuer: 'https://idp.example.com',
+            authorization_endpoint: 'https://idp.example.com/auth',
+            token_endpoint: 'https://idp.example.com/token',
+          }),
+        });
+
+        const response = await request(app)
+          .post('/api/sso/providers/oidc/test')
+          .send();
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+        expect(response.body.message).toContain('discovery successful');
+      });
+
+      it('should return error when discovery document missing required fields', async () => {
+        globalThis.__ssoTestMockResult = {
+          id: 1,
+          type: 'oidc',
+          name: 'OIDC',
+          config: {
+            issuerUrl: 'https://idp.example.com',
+            clientId: 'oidc-client',
+            clientSecret: 'oidc-secret',
+          },
+          isEnabled: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        globalThis.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ issuer: 'https://idp.example.com' }),
+        });
+
+        const response = await request(app)
+          .post('/api/sso/providers/oidc/test')
+          .send();
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(false);
+        expect(response.body.message).toContain('missing required fields');
+      });
+
+      it('should return error when discovery endpoint returns non-200', async () => {
+        globalThis.__ssoTestMockResult = {
+          id: 1,
+          type: 'oidc',
+          name: 'OIDC',
+          config: {
+            issuerUrl: 'https://idp.example.com',
+            clientId: 'oidc-client',
+            clientSecret: 'oidc-secret',
+          },
+          isEnabled: false,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        globalThis.fetch = vi.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          json: () => Promise.resolve({}),
+        });
+
+        const response = await request(app)
+          .post('/api/sso/providers/oidc/test')
+          .send();
+
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(false);
+        expect(response.body.message).toContain('HTTP 404');
+      });
+    });
+
     describe('LDAP provider', () => {
       it('should return success when LDAP bind succeeds', async () => {
         globalThis.__ssoTestMockResult = {

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -14,6 +14,7 @@ import AlertTriangle from 'lucide-react/dist/esm/icons/alert-triangle';
 import MonitorPlay from 'lucide-react/dist/esm/icons/monitor-play';
 import KeyRound from 'lucide-react/dist/esm/icons/key-round';
 import ShieldCheck from 'lucide-react/dist/esm/icons/shield-check';
+import LogIn from 'lucide-react/dist/esm/icons/log-in';
 import { APP_VERSION } from '@/lib/constants';
 
 function LoginPageContent() {
@@ -205,6 +206,9 @@ function LoginPageContent() {
                     )}
                     {provider.type === 'saml' && (
                       <ShieldCheck className="w-5 h-5 mr-2" />
+                    )}
+                    {provider.type === 'oidc' && (
+                      <LogIn className="w-5 h-5 mr-2" />
                     )}
                     Login with {provider.name}
                   </Button>

--- a/apps/web/src/components/settings/sso-settings.tsx
+++ b/apps/web/src/components/settings/sso-settings.tsx
@@ -17,7 +17,7 @@ import Save from 'lucide-react/dist/esm/icons/save';
 import Shield from 'lucide-react/dist/esm/icons/shield';
 import Zap from 'lucide-react/dist/esm/icons/zap';
 
-type SSOProviderType = 'ldap' | 'saml' | 'google' | 'plex';
+type SSOProviderType = 'ldap' | 'saml' | 'google' | 'plex' | 'oidc';
 
 interface SSOProvider {
   id: string;
@@ -41,6 +41,7 @@ interface FieldConfig {
   required?: boolean;
   helpText?: string;
   placeholder?: string;
+  advanced?: boolean;
 }
 
 const providerConfigs: ProviderConfig[] = [
@@ -71,6 +72,21 @@ const providerConfigs: ProviderConfig[] = [
     ],
   },
   {
+    type: 'oidc',
+    name: 'OIDC',
+    description: 'Generic OpenID Connect',
+    fields: [
+      { key: 'issuerUrl', label: 'Issuer URL', type: 'text', required: true, placeholder: 'https://idp.example.com/realms/myrealm', helpText: 'Base URL of the OIDC provider (the .well-known/openid-configuration is appended automatically)' },
+      { key: 'clientId', label: 'Client ID', type: 'text', required: true, placeholder: 'mixarr' },
+      { key: 'clientSecret', label: 'Client Secret', type: 'password', required: true },
+      { key: 'scopes', label: 'Scopes', type: 'text', placeholder: 'openid email profile', helpText: 'Space-separated list. Defaults to "openid email profile".' },
+      { key: 'allowedDomains', label: 'Allowed Domains', type: 'text', placeholder: 'example.com, company.org', helpText: 'Comma-separated list. Leave empty for all.' },
+      { key: 'emailAttribute', label: 'Email Claim', type: 'text', placeholder: 'email', helpText: 'Override only if your provider returns email under a non-standard claim name.', advanced: true },
+      { key: 'displayNameAttribute', label: 'Display Name Claim', type: 'text', placeholder: 'name', helpText: 'Override only if your provider uses a non-standard claim for the user\'s full name.', advanced: true },
+      { key: 'usernameAttribute', label: 'Username Claim', type: 'text', placeholder: 'preferred_username', helpText: 'Fallback claim used when the display name claim is missing.', advanced: true },
+    ],
+  },
+  {
     type: 'google',
     name: 'Google',
     description: 'Allow users to sign in with their Google accounts',
@@ -98,6 +114,7 @@ export function SSOSettings() {
     saml: {},
     google: {},
     plex: {},
+    oidc: {},
   });
   const [showPasswords, setShowPasswords] = useState<Record<string, boolean>>({});
   const [isLoading, setIsLoading] = useState(true);
@@ -113,7 +130,7 @@ export function SSOSettings() {
         api.get<{ providers: SSOProvider[] }>('/api/sso/providers'),
         api.get<{ baseUrl: string }>('/api/settings/base-url'),
       ]);
-      
+
       if (providersRes.error) {
         addToast({ type: 'error', title: 'Failed to load SSO providers', message: providersRes.error });
       } else if (providersRes.data) {
@@ -125,7 +142,7 @@ export function SSOSettings() {
         });
         setFormData(newFormData);
       }
-      
+
       if (baseUrlRes.data?.baseUrl) {
         setBaseUrl(baseUrlRes.data.baseUrl);
       }
@@ -279,6 +296,56 @@ export function SSOSettings() {
           const isExpanded = expandedProvider === config.type;
           const isEnabled = provider?.isEnabled ?? false;
           const isSaved = !!provider;
+          const mainFields = config.fields.filter((f) => !f.advanced);
+          const advancedFields = config.fields.filter((f) => f.advanced);
+
+          const renderField = (field: FieldConfig) => (
+            <div key={field.key} className="space-y-2">
+              <label className="text-sm font-medium">
+                {field.label}
+                {field.required && <span className="text-destructive ml-1">*</span>}
+              </label>
+              {field.type === 'textarea' ? (
+                <textarea
+                  value={formData[config.type][field.key] || ''}
+                  onChange={(e) => handleFieldChange(config.type, field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  className="w-full min-h-[100px] px-3 py-2 text-sm rounded-md border border-input bg-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                />
+              ) : field.type === 'password' ? (
+                <div className="relative">
+                  <Input
+                    type={showPasswords[`${config.type}-${field.key}`] ? 'text' : 'password'}
+                    value={formData[config.type][field.key] || ''}
+                    onChange={(e) => handleFieldChange(config.type, field.key, e.target.value)}
+                    placeholder={field.placeholder || '••••••••'}
+                    className="pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => togglePasswordVisibility(`${config.type}-${field.key}`)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    {showPasswords[`${config.type}-${field.key}`] ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              ) : (
+                <Input
+                  type="text"
+                  value={formData[config.type][field.key] || ''}
+                  onChange={(e) => handleFieldChange(config.type, field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                />
+              )}
+              {field.helpText && (
+                <p className="text-xs text-muted-foreground">{field.helpText}</p>
+              )}
+            </div>
+          );
 
           return (
             <div key={config.type} className="rounded-container border">
@@ -333,53 +400,19 @@ export function SSOSettings() {
               {/* Accordion Content */}
               {isExpanded && (
                 <div className="border-t p-4 space-y-4">
-                  {config.fields.map((field) => (
-                    <div key={field.key} className="space-y-2">
-                      <label className="text-sm font-medium">
-                        {field.label}
-                        {field.required && <span className="text-destructive ml-1">*</span>}
-                      </label>
-                      {field.type === 'textarea' ? (
-                        <textarea
-                          value={formData[config.type][field.key] || ''}
-                          onChange={(e) => handleFieldChange(config.type, field.key, e.target.value)}
-                          placeholder={field.placeholder}
-                          className="w-full min-h-[100px] px-3 py-2 text-sm rounded-md border border-input bg-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-                        />
-                      ) : field.type === 'password' ? (
-                        <div className="relative">
-                          <Input
-                            type={showPasswords[`${config.type}-${field.key}`] ? 'text' : 'password'}
-                            value={formData[config.type][field.key] || ''}
-                            onChange={(e) => handleFieldChange(config.type, field.key, e.target.value)}
-                            placeholder={field.placeholder || '••••••••'}
-                            className="pr-10"
-                          />
-                          <button
-                            type="button"
-                            onClick={() => togglePasswordVisibility(`${config.type}-${field.key}`)}
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                          >
-                            {showPasswords[`${config.type}-${field.key}`] ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </button>
-                        </div>
-                      ) : (
-                        <Input
-                          type="text"
-                          value={formData[config.type][field.key] || ''}
-                          onChange={(e) => handleFieldChange(config.type, field.key, e.target.value)}
-                          placeholder={field.placeholder}
-                        />
-                      )}
-                      {field.helpText && (
-                        <p className="text-xs text-muted-foreground">{field.helpText}</p>
-                      )}
-                    </div>
-                  ))}
+                  {mainFields.map(renderField)}
+
+                  {advancedFields.length > 0 && (
+                    <details className="group rounded-container border border-dashed">
+                      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm font-medium text-muted-foreground select-none hover:text-foreground [&::-webkit-details-marker]:hidden">
+                        <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+                        Advanced (Claim mappings)
+                      </summary>
+                      <div className="space-y-4 border-t border-dashed px-3 py-3">
+                        {advancedFields.map(renderField)}
+                      </div>
+                    </details>
+                  )}
 
                   {/* Google OAuth Callback URL Info */}
                   {config.type === 'google' && (
@@ -387,9 +420,9 @@ export function SSOSettings() {
                       <p className="font-medium text-amber-900 dark:text-amber-100">OAuth Redirect URI</p>
                       <p className="mt-1 text-amber-800 dark:text-amber-200">
                         Add this redirect URI in your{' '}
-                        <a 
-                          href="https://console.cloud.google.com/apis/credentials" 
-                          target="_blank" 
+                        <a
+                          href="https://console.cloud.google.com/apis/credentials"
+                          target="_blank"
                           rel="noopener noreferrer"
                           className="underline hover:no-underline"
                         >
@@ -411,6 +444,19 @@ export function SSOSettings() {
                       </p>
                       <code className="mt-2 block rounded bg-amber-100 dark:bg-amber-900/50 px-2 py-1 font-mono text-xs text-amber-900 dark:text-amber-100 break-all">
                         {baseUrl ? `${baseUrl}/api/auth/sso/saml/callback` : 'Configure Base URL in Global Settings first'}
+                      </code>
+                    </div>
+                  )}
+
+                  {/* OIDC Callback URL Info */}
+                  {config.type === 'oidc' && (
+                    <div className="rounded-container bg-amber-50 dark:bg-amber-950/50 p-3 text-sm">
+                      <p className="font-medium text-amber-900 dark:text-amber-100">OIDC Redirect URI</p>
+                      <p className="mt-1 text-amber-800 dark:text-amber-200">
+                        Register this redirect URI with your OpenID Connect provider:
+                      </p>
+                      <code className="mt-2 block rounded bg-amber-100 dark:bg-amber-900/50 px-2 py-1 font-mono text-xs text-amber-900 dark:text-amber-100 break-all">
+                        {baseUrl ? `${baseUrl}/api/auth/sso/oidc/callback` : 'Configure Base URL in Global Settings first'}
                       </code>
                     </div>
                   )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mixarr",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mixarr",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -21,7 +21,7 @@
     },
     "apps/api": {
       "name": "@mixarr/api",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
         "@mixarr/shared-types": "*",
@@ -39,6 +39,7 @@
         "helmet": "^8.0.0",
         "ioredis": "^5.4.1",
         "openai": "^4.73.0",
+        "openid-client": "^5.7.1",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-ldapauth": "^3.0.1",
@@ -71,7 +72,7 @@
     },
     "apps/web": {
       "name": "@mixarr/web",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "dependencies": {
         "@mixarr/shared-types": "*",
         "@tanstack/react-query": "^5.90.12",
@@ -7567,6 +7568,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8761,6 +8771,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8835,6 +8854,48 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/optionator": {
       "version": "0.9.4",


### PR DESCRIPTION
Adds a generic OIDC auth strategy alongside the existing LDAP, SAML, Google, and Plex ones. It uses the standard discovery endpoint (`.well-known/openid-configuration`), so anything spec-compliant should work: Keycloak, Authentik, Authelia, Okta, Auth0, etc.

Closes #26

## What's included

**Backend (`apps/api`)**
- Added `oidc` to the `SsoProviderType` Prisma enum (migration `20260522000001_add_oidc_provider`)
- New strategy at `apps/api/src/auth/strategies/oidc.ts`, built on `openid-client` v5
- Two new routes: `GET /api/auth/sso/oidc` to start the flow, and `GET /api/auth/sso/oidc/callback` to finish it
- The admin `POST /api/sso/providers/:type/test` endpoint now handles the OIDC case. It fetches the discovery doc and checks that the required fields are present.
- Zod schema and a runtime validator for the OIDC config
- `clientSecret` masking is already handled by `SsoProviderService`, so nothing new there

**Frontend (`apps/web`)**
- OIDC entry in the SSO settings accordion. Fields: Issuer URL, Client ID, Client Secret, Scopes, Allowed Domains.
- Optional "Advanced: Claim mappings" section, collapsed by default. Three override fields for Email, Display Name, and Username claims. Most providers won't need these; they're only there for the weird ones.
- Login page button for OIDC. It shows up automatically once the provider is enabled.
- A callout in the admin UI that shows the redirect URI you need to register with your IdP

**Dependency**
- `openid-client@^5.7.1`
