### PR TITLE
fix: update default OpenAI model and add configurable ListenBrainz URL

### DIFF
--- a/apps/api/src/jobs/strategies/listenbrainz.ts
+++ b/apps/api/src/jobs/strategies/listenbrainz.ts
@@ -31,7 +31,7 @@ function getListenBrainzService(context: StrategyContext): { service: ListenBrai
   if (!isListenBrainzConfig(conn.config)) throw new Error('Invalid ListenBrainz connection config');
   const username = context.config.username || conn.config.username;
   if (!username) throw new Error('ListenBrainz username not found. Check your ListenBrainz connection settings.');
-  return { service: new ListenBrainzService(username, conn.config.token), username };
+  return { service: new ListenBrainzService(username, conn.config.token, undefined, conn.config.url), username };
 }
 
 

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -156,7 +156,7 @@ const connectionTestHandlers: Record<string, (config: Record<string, any>) => Pr
 
   listenbrainz: async (config) => {
     try {
-      const service = new ListenBrainzService(config.username, config.token);
+      const service = new ListenBrainzService(config.username, config.token, undefined, config.url);
       const isValid = await service.validateUser();
       return {
         success: isValid,

--- a/apps/api/src/services/ai.ts
+++ b/apps/api/src/services/ai.ts
@@ -31,7 +31,7 @@ interface AISettings {
   anthropicStrategy: AIStrategy;
 }
 
-const DEFAULT_OPENAI_MODEL = 'gpt-3.5-turbo';
+const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
 
 /**
  * Placeholder API key for OpenAI-compatible endpoints that don't require auth.

--- a/apps/api/src/services/listenbrainz.ts
+++ b/apps/api/src/services/listenbrainz.ts
@@ -193,16 +193,17 @@ export const VALID_PERIODS: ListenBrainzPeriod[] = ['week', 'month', 'quarter', 
 export class ListenBrainzService {
   private username: string;
   private token?: string;
-  private baseUrl = 'https://api.listenbrainz.org';
+  private baseUrl: string;
   private timeoutMs: number;
 
-  constructor(username: string, token?: string, timeoutMs: number = DEFAULT_TIMEOUT_MS) {
+  constructor(username: string, token?: string, timeoutMs?: number, baseUrl?: string) {
     if (!username || username.trim() === '') {
       throw new Error('ListenBrainz username is required');
     }
     this.username = username.trim();
     this.token = token;
-    this.timeoutMs = timeoutMs;
+    this.timeoutMs = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.baseUrl = baseUrl ? baseUrl.replace(/\/$/, '') : 'https://api.listenbrainz.org';
   }
 
   /**

--- a/apps/api/src/types/connections.ts
+++ b/apps/api/src/types/connections.ts
@@ -98,6 +98,7 @@ export function isTidalConfig(config: unknown): config is TidalConnectionConfig 
 export interface ListenBrainzConnectionConfig {
   username: string;
   token?: string;
+  url?: string;
   [key: string]: JsonValue | undefined;
 }
 

--- a/apps/api/src/types/connections.ts
+++ b/apps/api/src/types/connections.ts
@@ -107,7 +107,10 @@ export function isListenBrainzConfig(config: unknown): config is ListenBrainzCon
     return false;
   }
   const c = config as Record<string, unknown>;
-  return typeof c.username === 'string';
+  return (
+    typeof c.username === 'string' &&
+    (c.url === undefined || typeof c.url === 'string')
+  );
 }
 
 // =============================================================================

--- a/apps/api/tests/services/ai.test.ts
+++ b/apps/api/tests/services/ai.test.ts
@@ -219,7 +219,7 @@ describe('AIService', () => {
 
       expect(mockOpenAICreate).toHaveBeenCalled();
       const callArgs = mockOpenAICreate.mock.calls[0][0];
-      expect(callArgs.model).toBe('gpt-3.5-turbo');
+      expect(callArgs.model).toBe('gpt-4o-mini');
     });
 
     it('should work with custom base URL and no API key (Ollama mode)', async () => {

--- a/apps/web/src/app/connections/components/forms/ListenBrainzForm.tsx
+++ b/apps/web/src/app/connections/components/forms/ListenBrainzForm.tsx
@@ -14,18 +14,20 @@ export function ListenBrainzForm({
 }: ConnectionFormProps) {
   const [username, setUsername] = useState(initialConfig?.username ?? '');
   const [token, setToken] = useState(initialConfig?.token ?? '');
+  const [url, setUrl] = useState(initialConfig?.url ?? '');
   const [showPassword, setShowPassword] = useState(false);
 
   useEffect(() => {
     if (username) {
       const config: Record<string, any> = { username };
       if (token) config.token = token;
+      if (url) config.url = url;
       onConfigReady(config);
     } else {
       onConfigInvalid();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [username, token]);
+  }, [username, token, url]);
 
   return (
     <>
@@ -75,6 +77,18 @@ export function ListenBrainzForm({
         </div>
         <p className="text-xs text-muted-foreground mt-1">
           Optional. Get from listenbrainz.org/profile
+        </p>
+      </div>
+      <div>
+        <label className="text-sm font-medium">API URL (optional)</label>
+        <Input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://api.listenbrainz.org"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Leave blank for ListenBrainz. Set to your Koito instance URL for self-hosted scrobbling.
         </p>
       </div>
     </>

--- a/apps/web/src/components/settings/ai-settings.tsx
+++ b/apps/web/src/components/settings/ai-settings.tsx
@@ -197,7 +197,7 @@ export function AISettings() {
                   type="text"
                   value={openaiModel}
                   onChange={(e) => setOpenaiModel(e.target.value)}
-                  placeholder="gpt-3.5-turbo (default)"
+                  placeholder="gpt-4o-mini (default)"
                 />
                 <p className="text-xs text-muted-foreground">
                   Model name varies by provider (e.g., llama3.2, mistral, gpt-4o)


### PR DESCRIPTION
## Summary

Two small fixes from issue triage.

### Fix #52 — Update `DEFAULT_OPENAI_MODEL`
The default OpenAI model was `gpt-3.5-turbo`, which is outdated and deprecated. Updated to `gpt-4o-mini` to match what the README already documented as the default.

**Files:** `services/ai.ts`, `ai-settings.tsx` placeholder, test assertion.

### Fix #25 — Configurable ListenBrainz base URL (Koito support)
[Koito](https://koito.io/) is a ListenBrainz-compatible self-hosted scrobbler. Since it uses the same API, adding an optional `url` field to the connection config covers it without any new integration work.

Changes are fully backward-compatible — existing connections without a URL continue using `https://api.listenbrainz.org`.

**Files:**
- `types/connections.ts` — added `url?` to `ListenBrainzConnectionConfig`
- `services/listenbrainz.ts` — accepts optional `baseUrl` constructor param (4th arg, trailing slash stripped)
- `routes/connections.ts` — passes `config.url` to service in connection test handler
- `jobs/strategies/listenbrainz.ts` — passes `conn.config.url` when resolving the service
- `ListenBrainzForm.tsx` — adds optional "API URL" field with Koito hint

Closes #52
Closes #25